### PR TITLE
Add marketplace.json for Claude plugin marketplace distribution

### DIFF
--- a/plugins/ui5-typescript-conversion/.claude-plugin/marketplace.json
+++ b/plugins/ui5-typescript-conversion/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "ui5-typescript-conversion",
+  "owner": {
+    "name": "SAP SE"
+  },
+  "plugins": [
+    {
+      "name": "ui5-typescript-conversion",
+      "description": "Convert JavaScript-based SAPUI5/OpenUI5 projects to TypeScript.",
+      "source": "./"
+    }
+  ]
+}

--- a/plugins/ui5/.claude-plugin/marketplace.json
+++ b/plugins/ui5/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "ui5",
+  "owner": {
+    "name": "SAP SE"
+  },
+  "plugins": [
+    {
+      "name": "ui5",
+      "description": "SAPUI5/OpenUI5 plugin for Claude. Create and validate UI5 projects, access API documentation, run UI5 linter, and get development guidelines.",
+      "source": "./"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` to both plugins to enable distribution via the Claude plugin marketplace (`claude.com/plugins`).

- **plugins/ui5**: marketplace.json with plugin metadata
- **plugins/ui5-typescript-conversion**: marketplace.json with plugin metadata

These files are required for marketplace discovery and `claude plugin install` to work. No changes to existing plugin functionality.

## Context

Both plugins already have the correct `.claude-plugin/plugin.json` and `.mcp.json` structure. This adds the last missing piece for marketplace compatibility.