### PR TITLE
docs: Add installation guides for coding agents without plugin concept

### DIFF
--- a/plugins/ui5-typescript-conversion/README.md
+++ b/plugins/ui5-typescript-conversion/README.md
@@ -18,3 +18,10 @@ In Claude Code:
 /plugin install ui5-typescript-conversion@claude-plugins-official
 ```
 
+## Installing skills only
+
+If your coding agent does not support plugins, you can install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:
+
+```bash
+npx skills add UI5/plugins-coding-agents
+```

--- a/plugins/ui5-typescript-conversion/README.md
+++ b/plugins/ui5-typescript-conversion/README.md
@@ -18,9 +18,9 @@ In Claude Code:
 /plugin install ui5-typescript-conversion@claude-plugins-official
 ```
 
-## Installing skills only
+## Installing Skills Only
 
-If your coding agent does not support plugins, you can install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:
+If your coding agent doesn't support plugins, install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:
 
 ```bash
 npx skills add UI5/plugins-coding-agents

--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -22,3 +22,12 @@ In Claude Code:
 /plugin install ui5@claude-plugins-official
 ```
 
+## Installing skills only
+
+If your coding agent does not support plugins, you can install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:
+
+```bash
+npx skills add UI5/plugins-coding-agents
+```
+
+> **Note:** You also need to install the [UI5 MCP server](https://github.com/UI5/mcp-server) manually. When using the plugin, this is handled automatically.

--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -30,4 +30,4 @@ If your coding agent doesn't support plugins, install the skills directly using 
 npx skills add UI5/plugins-coding-agents
 ```
 
-> **Note:** You also need to install the [UI5 MCP server](https://github.com/UI5/mcp-server) manually. When using the plugin, this is handled automatically.
+> **Note:** When installing the skills only, you will need to install the [UI5 MCP server](https://github.com/UI5/mcp-server) manually.

--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -22,9 +22,9 @@ In Claude Code:
 /plugin install ui5@claude-plugins-official
 ```
 
-## Installing skills only
+## Installing Skills Only
 
-If your coding agent does not support plugins, you can install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:
+If your coding agent doesn't support plugins, install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:
 
 ```bash
 npx skills add UI5/plugins-coding-agents


### PR DESCRIPTION
Adding installations commands for coding agents without a plugin concept