### PR TITLE
fix: Update release-please extra-files to current plugin.json paths

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,12 +66,22 @@
             "extra-files": [
                 {
                     "type": "json",
-                    "path": "plugins/ui5/.claude-plugin/plugin.json",
+                    "path": "plugins/ui5/plugin.json",
                     "jsonpath": "$..version"
                 },
                 {
                     "type": "json",
-                    "path": "plugins/ui5-typescript-conversion/.claude-plugin/plugin.json",
+                    "path": "plugins/ui5/.github/plugin/plugin.json",
+                    "jsonpath": "$..version"
+                },
+                {
+                    "type": "json",
+                    "path": "plugins/ui5-typescript-conversion/plugin.json",
+                    "jsonpath": "$..version"
+                },
+                {
+                    "type": "json",
+                    "path": "plugins/ui5-typescript-conversion/.github/plugin/plugin.json",
                     "jsonpath": "$..version"
                 }
             ]


### PR DESCRIPTION
The `.claude-plugin/plugin.json` files no longer exist. Plugin manifests now live at `plugins/<name>/plugin.json` and a copy at `plugins/<name>/.github/plugin/plugin.json` (for Windows-safe discovery). Point release-please at all four so versions stay in sync on release.

