### PR TITLE
fix: Make plugin.json prettier-stable after release-please bumps

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,13 @@
     "trailingComma": "es5",
     "tabWidth": 4,
     "semi": false,
-    "singleQuote": false
+    "singleQuote": false,
+    "overrides": [
+        {
+            "files": ["**/plugin.json"],
+            "options": {
+                "parser": "json-stringify"
+            }
+        }
+    ]
 }

--- a/plugins/ui5-typescript-conversion/.github/plugin/plugin.json
+++ b/plugins/ui5-typescript-conversion/.github/plugin/plugin.json
@@ -17,5 +17,7 @@
         "typescript",
         "conversion"
     ],
-    "skills": ["./skills/"]
+    "skills": [
+        "./skills/"
+    ]
 }

--- a/plugins/ui5-typescript-conversion/plugin.json
+++ b/plugins/ui5-typescript-conversion/plugin.json
@@ -17,5 +17,7 @@
         "typescript",
         "conversion"
     ],
-    "skills": ["./skills/"]
+    "skills": [
+        "./skills/"
+    ]
 }

--- a/plugins/ui5/.github/plugin/plugin.json
+++ b/plugins/ui5/.github/plugin/plugin.json
@@ -19,5 +19,7 @@
         "development-guidelines",
         "best-practices"
     ],
-    "skills": ["./skills/"]
+    "skills": [
+        "./skills/"
+    ]
 }

--- a/plugins/ui5/plugin.json
+++ b/plugins/ui5/plugin.json
@@ -19,5 +19,7 @@
         "development-guidelines",
         "best-practices"
     ],
-    "skills": ["./skills/"]
+    "skills": [
+        "./skills/"
+    ]
 }


### PR DESCRIPTION
release-please's JSON updater re-stringifies the file with JSON.stringify(obj, null, indent), which always expands arrays to multi-line. The inline "skills": ["./skills/"] in plugin.json was therefore reformatted to multi-line on every release, and the subsequent prettier:check failed because prettier collapsed it again.

Switch the prettier parser to json-stringify for **/plugin.json (same parser prettier already uses for package.json), which keeps every array multi-line — matching what release-please produces. Reformat the four plugin.json files in source so the check passes today.
