### PR TITLE
fix(ui5-modernization): Fix skill spec conformance errors

### DIFF
--- a/plugins/ui5-modernization/skills/fix-control-renderer/SKILL.md
+++ b/plugins/ui5-modernization/skills/fix-control-renderer/SKILL.md
@@ -2,11 +2,11 @@
 name: fix-control-renderer
 description: |
   Fix Control renderer issues that UI5 linter reports but cannot auto-fix. Use this skill when linter outputs these rules:
-  - `no-deprecated-control-renderer-declaration` - For missing renderer declaration, string-based renderer declaration, implicit renderer auto-discovery (UI5 1.x loads `<Control>Renderer` automatically — removed in modern UI5)
-  - `no-deprecated-api` - For missing apiVersion:2 in control renderer objects, missing IconPool import when using oRm.icon(), deprecated rerender() override. NOTE: For Library.init() apiVersion errors, use fix-library-init instead.
+  - `no-deprecated-control-renderer-declaration` - For missing renderer declaration, string-based renderer declaration, implicit renderer auto-discovery (removed in modern UI5)
+  - `no-deprecated-api` - For missing apiVersion:2 in renderer objects, missing IconPool import when using oRm.icon(), deprecated rerender() override. NOTE: For Library.init() apiVersion errors, use fix-library-init instead.
   - `ui5-class-declaration` - For non-static renderer property in ES6 classes
-  Trigger on error messages about: "missing a renderer declaration", "Deprecated declaration of renderer", "deprecated renderer", "deprecated renderer detected", "apiVersion" (in renderer context, NOT "Deprecated call to ... Lib.init"), "IconPool", "rerender", "renderer must be a static property"
-  Automatically converts legacy renderer patterns to modern apiVersion: 2 format with proper module imports. Handles implicit renderer auto-discovery where UI5 1.x automatically loaded a renderer from the default path (e.g., sap/m/ButtonRenderer for sap/m/Button) — in modern UI5 this must be explicit.
+  Trigger on: "missing a renderer declaration", "Deprecated declaration of renderer", "deprecated renderer", "apiVersion" (in renderer context), "IconPool", "rerender", "renderer must be a static property"
+  Converts legacy renderer patterns to modern apiVersion: 2 format with proper module imports.
 ---
 
 # Fix Control Renderer Issues

--- a/plugins/ui5-modernization/skills/fix-js-globals/SKILL.md
+++ b/plugins/ui5-modernization/skills/fix-js-globals/SKILL.md
@@ -3,21 +3,19 @@ name: fix-js-globals
 description: |
   Fix JavaScript `no-globals` errors that UI5 linter reports but cannot auto-fix. Use this skill when linter outputs:
   - `no-globals` rule with message "Access of global variable '...' (...)" in JS files
-  Cases that require this skill (linter CANNOT auto-fix):
+  Cases handled (linter CANNOT auto-fix):
   - Assignments to global namespaces: `sap.myNamespace = {...}`
-  - Global namespace assignment inside sap.ui.define: `my.app.utils.Module = {...}; return my.app.utils.Module;` — replace with local variable
-  - Global namespace read-only reference inside sap.ui.define: `var x = com.example.app.utils.Helper` — replace with proper dependency import
+  - Global namespace assignment/read inside sap.ui.define
   - Delete expressions: `delete sap.something`
-  - sap.ui.core.Core direct access (class vs singleton difference)
-  - jQuery/$ global calls: add `sap/ui/thirdparty/jquery` dependency, replace `$` with dependency variable — do NOT replace jQuery API calls (including static methods like jQuery.each, jQuery.extend, jQuery.proxy)
-  - jQuery.sap.* deprecated utilities (jQuery.sap.log, jQuery.sap.uid, etc.): replace with dedicated replacement modules
-  - Conditional/probing global access: `if (sap.ui.something)`
+  - sap.ui.core.Core direct access (class vs singleton)
+  - jQuery/$ globals: add `sap/ui/thirdparty/jquery` — do NOT replace jQuery API calls
+  - jQuery.sap.* utilities: replace with dedicated modules
+  - Conditional/probing access: `if (sap.ui.something)`
   - Custom namespace definitions that aren't UI5 modules
-  - Global access in binding type strings without imports
-  - sap.ui.controller() factory: define controllers via deprecated global (two-argument form → Controller.extend). Covers legacy files with or without sap.ui.define. Does NOT handle Fiori Elements extensions (use fix-fiori-elements-extensions when manifest has sap.ui.controllerExtensions)
-  - jQuery.sap.declare/require: legacy module definitions without sap.ui.define wrapper
-  Trigger when user mentions: "fix no-globals", "global variable error", "sap.ui.getCore", "window.sap", "jQuery.sap", "global namespace"
-  Automatically converts global namespace access to proper sap.ui.define module imports.
+  - sap.ui.controller() factory → Controller.extend (NOT Fiori Elements extensions)
+  - jQuery.sap.declare/require: legacy modules without sap.ui.define
+  Trigger when: "fix no-globals", "global variable error", "sap.ui.getCore", "jQuery.sap"
+  Converts global namespace access to proper sap.ui.define module imports.
 ---
 
 # Fix JavaScript Global Access (no-globals)

--- a/plugins/ui5-modernization/skills/fix-linter-blind-spots/SKILL.md
+++ b/plugins/ui5-modernization/skills/fix-linter-blind-spots/SKILL.md
@@ -8,10 +8,9 @@ description: |
   - User mentions "runtime errors after modernization", "test failures after modernization", "global namespace still used"
   - After running fix-js-globals and fix-cyclic-deps, but tests STILL fail
   - User sees "X is not a constructor" or module loading errors in test output
-  The linter only checks sap.* globals in JS. App-specific namespace patterns in JavaScript (e.g., com.example.app.utils.Module)
-  are invisible to it. This skill detects and fixes those patterns across ALL JS files — app source AND test.
-  NOTE: App-namespace globals in XML files ARE reported by the linter (`no-globals` rule) and are handled by
-  `fix-xml-globals` in Phase 3 — NOT by this skill.
+  The linter only checks sap.* globals in JS. App-specific namespace patterns (e.g., com.example.app.utils.Module)
+  are invisible to it. This skill detects and fixes those across ALL JS files — app source AND test.
+  NOTE: App-namespace globals in XML files are handled by `fix-xml-globals` — NOT by this skill.
 ---
 
 # Fix Linter Blind Spots

--- a/plugins/ui5-modernization/skills/fix-xml-globals/SKILL.md
+++ b/plugins/ui5-modernization/skills/fix-xml-globals/SKILL.md
@@ -2,12 +2,12 @@
 name: fix-xml-globals
 description: |
   Fix XML view/fragment issues that UI5 linter reports but cannot auto-fix. Use this skill when linter outputs these rules:
-  - `no-globals` - For ALL global variable access in XML views — sap.*, jQuery.*, AND app-namespace globals (e.g., com.example.app.utils.Handler.onPress, my.app.formatter.method, sap.ui.model.type.Currency)
+  - `no-globals` - For ALL global variable access in XML views — sap.*, jQuery.*, AND app-namespace globals (e.g., com.example.app.utils.Handler.onPress, my.app.formatter.method)
   - `no-ambiguous-event-handler` - For event handlers without dot prefix or local name
   - `no-deprecated-api` - For legacy template:require syntax (space-separated)
   Trigger on XML view/fragment files with errors about global variables, event handlers, formatters, type references in bindings, factory functions, or template:require.
   Automatically adds core:require declarations, fixes event handler prefixes, and handles .bind($control) for functions that use 'this'.
-  IMPORTANT: The linter reports app-namespace globals in XML under `no-globals` — these MUST be fixed by this skill in Phase 3, NOT deferred to fix-linter-blind-spots (Phase 3, Step 3.2).
+  IMPORTANT: The linter reports app-namespace globals in XML under `no-globals` — these MUST be fixed by this skill, NOT deferred to fix-linter-blind-spots.
   For native HTML or SVG in XML views, use the fix-xml-native-html skill instead.
 ---
 

--- a/plugins/ui5-modernization/skills/modernize-flp-sandbox/SKILL.md
+++ b/plugins/ui5-modernization/skills/modernize-flp-sandbox/SKILL.md
@@ -453,8 +453,7 @@ default (report only).
 ### 6i. QUnit 1.x → 2.x patterns in OPA test code (handoff)
 
 **Layer:** advisory. The actual rewrite lives in the
-`modernize-flp-sandbox-qunit` sub-skill (under
-[`skills/modernize-flp-sandbox-qunit/`](skills/modernize-flp-sandbox-qunit/SKILL.md)).
+`modernize-flp-sandbox-qunit` sub-skill.
 The main skill detects, reports, and offers to invoke the sub-skill
 on consumer request.
 

--- a/plugins/ui5-modernization/skills/modernize-test-starter/SKILL.md
+++ b/plugins/ui5-modernization/skills/modernize-test-starter/SKILL.md
@@ -8,13 +8,12 @@ description: |
   - Test JS files use Core.ready(), Core.attachInit(), or jsUnitTestSuite instead of sap.ui.define
   - OPA test HTML files exist with per-test Opa5.extendConfig and manual bootstrapping
   - An AllJourneys.js orchestrator loads OPA journeys dynamically
-  - OPA journeys call `iStartMyUIComponent` (in-window component launcher) instead of `iStartMyAppInAFrame` — skill migrates to a bare-Component iframe in Phase 5b
+  - OPA journeys call `iStartMyUIComponent` instead of `iStartMyAppInAFrame`
   - User asks to modernize tests, modernize test infrastructure, or adopt Test Starter
-  Handles both unit tests (Core.ready removal, sap.ui.define wrapping) and OPA-specific challenges
-  (page-object side-effect imports, Opa5 config, journey orchestration, QUnit 1.x assert modernization,
+  Handles unit tests (Core.ready removal, sap.ui.define wrapping) and OPA challenges
+  (page-object imports, Opa5 config, journey orchestration, QUnit 1.x assert modernization,
   in-window-to-iframe launcher migration).
-  Trigger on: prefer-test-starter linter warnings, test modernization requests, "test runner" modernization,
-  iStartMyUIComponent in-window OPA launchers.
+  Trigger on: prefer-test-starter warnings, test modernization requests, iStartMyUIComponent.
 ---
 
 # Modernize to Test Starter


### PR DESCRIPTION
- Shorten descriptions to ≤1024 chars for fix-linter-blind-spots, fix-control-renderer, modernize-test-starter, fix-js-globals, and fix-xml-globals
- Remove 2-level-deep file reference in modernize-flp-sandbox (skills/modernize-flp-sandbox-qunit/SKILL.md link removed)

Fixes validation errors reported in https://github.com/github/awesome-copilot/issues/2114#issuecomment-4789690191.