### PR TITLE
feat(ui5): Add accessibility best practices skill

### DIFF
--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -64,6 +64,19 @@ Authoritative development guidelines for all UI5 table controls (SAPUI5 1.136+ L
 - **Personalization** - `sap.m.p13n.Engine` integration
 - **Cell templates & alignment** - Type-based alignment and model type namespace rules
 
+#### ui5-best-practices-accessibility
+
+Accessibility guidelines and review checklist for UI5 views, fragments, and controllers:
+
+- **Landmarks** - `landmarkInfo` and `accessibleRole` for `DynamicPage`, `Page`, `Panel`, `ObjectPage`, `FlexibleColumnLayout`
+- **Labeling** - `<Label labelFor>` for inputs, `ariaLabelledBy` for tables, tooltips for icon-only buttons, `alt` for standalone icons and images
+- **Heading levels** - Explicit `level` on `<Title>`, no heading level jumps within a view
+- **Focus handling** - `initialFocus` on `Dialog`/`Popover`, fast navigation groups, no `tabindex > 0`
+- **Keyboard shortcuts** - `CommandExecution` for action buttons that should support keyboard shortcuts
+- **Invisible messaging** - `InvisibleMessage.announce()` for dynamic state changes visible to sighted users only
+- **Reading order** - Controls not visually reordered out of DOM sequence; `ariaDescribedBy` pointing to correct DOM order
+- **Target size** - `reactiveAreaMode` for interactive controls in dense layouts
+
 ---
 
 ## Installation

--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -28,6 +28,19 @@ Development guidelines and coding standards derived from official SAP UI5 guidel
 
 **Note**: For TypeScript conversion specifically, use the separate [`ui5-typescript-conversion`](https://github.com/UI5/plugins-coding-agents/tree/main/plugins/ui5-typescript-conversion) plugin.
 
+#### ui5-best-practices-accessibility
+
+Accessibility guidelines and review checklist for UI5 views, fragments, and controllers:
+
+- **Landmarks** - `landmarkInfo` and `accessibleRole` for `DynamicPage`, `Page`, `Panel`, `ObjectPage`, `FlexibleColumnLayout`
+- **Labeling** - `<Label labelFor>` for inputs, `ariaLabelledBy` for tables, tooltips for icon-only buttons, `alt` for standalone icons and images
+- **Heading levels** - Explicit `level` on `<Title>`, no heading level jumps within a view
+- **Focus handling** - `initialFocus` on `Dialog`/`Popover`, fast navigation groups, no `tabindex > 0`
+- **Keyboard shortcuts** - `CommandExecution` for action buttons that should support keyboard shortcuts
+- **Invisible messaging** - `InvisibleMessage.announce()` for dynamic state changes visible to sighted users only
+- **Reading order** - Controls not visually reordered out of DOM sequence; `ariaDescribedBy` pointing to correct DOM order
+- **Target size** - `reactiveAreaMode` for interactive controls in dense layouts
+
 #### ui5-best-practices-integration-cards
 
 Development guidelines for UI Integration Cards (also known as UI5 Integration Cards):
@@ -63,19 +76,6 @@ Authoritative development guidelines for all UI5 table controls (SAPUI5 1.136+ L
 - **Drag & drop** - Correct `DragDropInfo` and `DragInfo`/`DropInfo` configuration
 - **Personalization** - `sap.m.p13n.Engine` integration
 - **Cell templates & alignment** - Type-based alignment and model type namespace rules
-
-#### ui5-best-practices-accessibility
-
-Accessibility guidelines and review checklist for UI5 views, fragments, and controllers:
-
-- **Landmarks** - `landmarkInfo` and `accessibleRole` for `DynamicPage`, `Page`, `Panel`, `ObjectPage`, `FlexibleColumnLayout`
-- **Labeling** - `<Label labelFor>` for inputs, `ariaLabelledBy` for tables, tooltips for icon-only buttons, `alt` for standalone icons and images
-- **Heading levels** - Explicit `level` on `<Title>`, no heading level jumps within a view
-- **Focus handling** - `initialFocus` on `Dialog`/`Popover`, fast navigation groups, no `tabindex > 0`
-- **Keyboard shortcuts** - `CommandExecution` for action buttons that should support keyboard shortcuts
-- **Invisible messaging** - `InvisibleMessage.announce()` for dynamic state changes visible to sighted users only
-- **Reading order** - Controls not visually reordered out of DOM sequence; `ariaDescribedBy` pointing to correct DOM order
-- **Target size** - `reactiveAreaMode` for interactive controls in dense layouts
 
 ---
 

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ui5-best-practices-accessibility
+description: >
+  This skill should be used when the user asks to audit, fix, check, review, or
+  improve accessibility, a11y, ARIA, landmarks, labeling, heading levels,
+  keyboard shortcuts, screen reader support, invisible messaging, reading order,
+  or touch target size in UI5 application files (views, fragments, controllers).
+  Also use when the user creates a new UI5 view, fragment, or controller and
+  wants it to be accessible, or asks whether a specific control (Dialog, Table,
+  Panel, etc.) meets accessibility requirements.
+allowed-tools: Read Bash AskUserQuestion
+---
+
+# Accessibility Review
+
+Accessibility in UI5 is incorporated in two levels: framework and application.
+This review supports what application developers must still provide explicitly
+to improve the accessibility of their application.
+
+## Step 1 — Find the files
+
+If `$ARGUMENTS` lists specific files, review only those.
+
+Otherwise, discover all app source files automatically:
+
+```!
+find . \( -name "*.view.xml" -o -name "*.fragment.xml" -o -name "*.controller.js" \) \
+  -not -path "*/node_modules/*" \
+  -not -path "*/dist/*" \
+  -not -path "*/test/*" \
+  -not -path "*/resources/*" \
+  | sort
+```
+
+If more than 15 files are found, use `AskUserQuestion` to let the user choose:
+- Review everything (may take a moment)
+- Focus on a specific folder or area
+
+Read each file in scope.
+
+## Step 2 — Review
+
+Check the code against the eight topics below. For each topic where you find a gap,
+**read the corresponding topic file before writing the fix** — it contains the correct
+API pattern and wrong/correct examples.
+
+| # | Topic | What to detect | Topic file |
+|---|-------|---------------|------------|
+| 1 | Landmarks | `DynamicPage`, `Page`, `Panel`, `ObjectPage`, `FlexibleColumnLayout` missing `landmarkInfo` or `accessibleRole`; landmark role set without its corresponding label (e.g. `rootRole` without `rootLabel`) | `${CLAUDE_SKILL_DIR}/references/landmark.md` |
+| 2 | Labeling | Inputs without `<Label labelFor>` (except inside `SimpleForm`); Tables without `ariaLabelledBy`; icon-only `Button` without `tooltip`; standalone `Icon` without `alt` and not marked `decorative`; `Image` with `decorative=false` and no `alt`; `Dialog` with `showHeader:false` and no `ariaLabelledBy` | `${CLAUDE_SKILL_DIR}/references/labeling.md` |
+| 3 | Heading levels | `<Title>` without explicit `level`; heading level jumps (e.g. H1 → H3) within a view | `${CLAUDE_SKILL_DIR}/references/heading.md` |
+| 4 | Focus handling | `Dialog` or `Popover` without `initialFocus` when a specific starting element is required; larger composite areas that act as distinct logical regions and need a `sap-ui-fastnavgroup` `CustomData` entry; `tabindex` values greater than 0 in rendered HTML | `${CLAUDE_SKILL_DIR}/references/keyboard.md` |
+| 5 | Keyboard shortcuts | Action buttons (save, delete, etc.) using plain `press=".onX"` that should support keyboard shortcuts but have no `CommandExecution` | `${CLAUDE_SKILL_DIR}/references/shortcut.md` |
+| 6 | Invisible messaging | Dynamic state changes (save confirmations, errors, filter results) that are visible-only with no `InvisibleMessage.announce()` call in the handler | `${CLAUDE_SKILL_DIR}/references/invisible-message.md` |
+| 7 | Reading order | Controls visually reordered via CSS/layout but out of sequence in XML; `ariaDescribedBy` pointing to IDs that appear later in the DOM | `${CLAUDE_SKILL_DIR}/references/reading-order.md` |
+| 8 | Target size | `Link`, `ObjectIdentifier`, `ObjectStatus`, `ObjectNumber`, `ObjectMarker`, `ObjectAttribute` inside an interactive container without `reactiveAreaMode`; or in other dense layout without spacing | `${CLAUDE_SKILL_DIR}/references/target-size.md` |
+
+## Step 3 — Report
+
+For each gap found:
+
+**Issue**: one line — names the control and the missing property/association
+**Impact**: `critical` (blocks AT users entirely) | `serious` (significant barrier) | `moderate` (partial barrier) | `minor` (best practice, low direct impact)
+**Why**: one sentence on user impact
+**Fix**: minimal corrected XML or JS snippet (only the changed part)
+
+Group findings by topic, critical/serious first within each group. End with a summary count by impact level.
+If no gaps are found, say so.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: ui5-best-practices-accessibility
-description: >
+description: |
   This skill should be used when the user asks to audit, fix, check, review, or
-  improve accessibility, a11y, ARIA, landmarks, labeling, heading levels,
-  keyboard shortcuts, screen reader support, invisible messaging, reading order,
-  or touch target size in UI5 application files (views, fragments, controllers).
-  Also use when the user creates a new UI5 view, fragment, or controller and
-  wants it to be accessible, or asks whether a specific control (Dialog, Table,
-  Panel, etc.) meets accessibility requirements.
-allowed-tools: Read Bash AskUserQuestion
+  improve accessibility, a11y, ARIA, WCAG compliance, landmarks, labeling, heading
+  levels, focus handling, keyboard navigation, keyboard shortcuts, screen reader
+  support, invisible messaging, reading order, or touch / target size in UI5
+  application files (views, fragments, controllers). Also use when the user
+  creates a new UI5 view, fragment, or controller and wants it to be accessible,
+  or asks whether a specific control (Dialog, Table, Panel, etc.) meets
+  accessibility requirements.
+
+  Keywords: accessibility, a11y, ARIA, WCAG, screen reader, NVDA, JAWS, VoiceOver,
+  landmark, landmarkInfo, accessibleRole, ariaLabelledBy, ariaDescribedBy,
+  labelFor, tooltip, alt text, decorative, heading level, initialFocus, F6,
+  fast nav, fastnavgroup, tabindex, CommandExecution, keyboard shortcut,
+  InvisibleMessage, announce, reading order, reactiveAreaMode, target size.
 ---
 
 # Accessibility Review
@@ -46,14 +52,14 @@ API pattern and wrong/correct examples.
 
 | # | Topic | What to detect | Topic file |
 |---|-------|---------------|------------|
-| 1 | Landmarks | `DynamicPage`, `Page`, `Panel`, `ObjectPage`, `FlexibleColumnLayout` missing `landmarkInfo` or `accessibleRole`; landmark role set without its corresponding label (e.g. `rootRole` without `rootLabel`) | `${CLAUDE_SKILL_DIR}/references/landmark.md` |
-| 2 | Labeling | Inputs without `<Label labelFor>` (except inside `SimpleForm`); Tables without `ariaLabelledBy`; icon-only `Button` without `tooltip`; standalone `Icon` without `alt` and not marked `decorative`; `Image` with `decorative=false` and no `alt`; `Dialog` with `showHeader:false` and no `ariaLabelledBy` | `${CLAUDE_SKILL_DIR}/references/labeling.md` |
-| 3 | Heading levels | `<Title>` without explicit `level`; heading level jumps (e.g. H1 → H3) within a view | `${CLAUDE_SKILL_DIR}/references/heading.md` |
-| 4 | Focus handling | `Dialog` or `Popover` without `initialFocus` when a specific starting element is required; larger composite areas that act as distinct logical regions and need a `sap-ui-fastnavgroup` `CustomData` entry; `tabindex` values greater than 0 in rendered HTML | `${CLAUDE_SKILL_DIR}/references/keyboard.md` |
-| 5 | Keyboard shortcuts | Action buttons (save, delete, etc.) using plain `press=".onX"` that should support keyboard shortcuts but have no `CommandExecution` | `${CLAUDE_SKILL_DIR}/references/shortcut.md` |
-| 6 | Invisible messaging | Dynamic state changes (save confirmations, errors, filter results) that are visible-only with no `InvisibleMessage.announce()` call in the handler | `${CLAUDE_SKILL_DIR}/references/invisible-message.md` |
-| 7 | Reading order | Controls visually reordered via CSS/layout but out of sequence in XML; `ariaDescribedBy` pointing to IDs that appear later in the DOM | `${CLAUDE_SKILL_DIR}/references/reading-order.md` |
-| 8 | Target size | `Link`, `ObjectIdentifier`, `ObjectStatus`, `ObjectNumber`, `ObjectMarker`, `ObjectAttribute` inside an interactive container without `reactiveAreaMode`; or in other dense layout without spacing | `${CLAUDE_SKILL_DIR}/references/target-size.md` |
+| 1 | Landmarks | `DynamicPage`, `Page`, `Panel`, `ObjectPage`, `FlexibleColumnLayout` missing `landmarkInfo` or `accessibleRole`; landmark role set without its corresponding label (e.g. `rootRole` without `rootLabel`) | `references/landmark.md` |
+| 2 | Labeling | Inputs without `<Label labelFor>` (except inside `SimpleForm`); Tables without `ariaLabelledBy`; icon-only `Button` without `tooltip`; standalone `Icon` without `alt` and not marked `decorative`; `Image` with `decorative=false` and no `alt`; `Dialog` with `showHeader:false` and no `ariaLabelledBy` | `references/labeling.md` |
+| 3 | Heading levels | `<Title>` without explicit `level`; heading level jumps (e.g. H1 → H3) within a view | `references/heading.md` |
+| 4 | Focus & keyboard | `Dialog` or `Popover` without `initialFocus` when a specific starting element is required; larger composite areas that act as distinct logical regions and need a `sap-ui-fastnavgroup` `CustomData` entry; `tabindex` values greater than 0 in rendered HTML | `references/keyboard.md` |
+| 5 | Keyboard shortcuts | Action buttons (save, delete, etc.) using plain `press=".onX"` that should support keyboard shortcuts but have no `CommandExecution` | `references/shortcut.md` |
+| 6 | Invisible messaging | Dynamic state changes (save confirmations, errors, filter results) that are visible-only with no `InvisibleMessage.announce()` call in the handler | `references/invisible-message.md` |
+| 7 | Reading order | Controls visually reordered via CSS/layout but out of sequence in XML; `ariaDescribedBy` pointing to IDs that appear later in the DOM | `references/reading-order.md` |
+| 8 | Target size | `Link`, `ObjectIdentifier`, `ObjectStatus`, `ObjectNumber`, `ObjectMarker`, `ObjectAttribute` inside an interactive container without `reactiveAreaMode`; or in other dense layout without spacing | `references/target-size.md` |
 
 ## Step 3 — Report
 

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/heading.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/heading.md
@@ -7,14 +7,14 @@ sections. Missing or skipped heading levels break this navigation.
 
 **Wrong:**
 ```xml
-<Title text="Order Details"/>
+<Title text="{i18n>orderDetailsTitle}"/>
 ```
 
 **Correct:**
 ```xml
-<Title level="H1" text="Order Details"/>    <!-- page title -->
-<Title level="H2" text="Line Items"/>       <!-- section header -->
-<Title level="H3" text="Item Notes"/>       <!-- subsection -->
+<Title level="H1" text="{i18n>orderDetailsTitle}"/>    <!-- page title -->
+<Title level="H2" text="{i18n>lineItemsTitle}"/>       <!-- section header -->
+<Title level="H3" text="{i18n>itemNotesTitle}"/>       <!-- subsection -->
 ```
 
 ## Heading hierarchy rules
@@ -33,7 +33,7 @@ When using the `title` property, the framework renders it as `<h1>` automaticall
 <Dialog>
   <customHeader>
     <Toolbar>
-      <Title id="dlgTitle" text="Confirm Deletion"/>
+      <Title id="dlgTitle" text="{i18n>confirmDeletionTitle}"/>
     </Toolbar>
   </customHeader>
 </Dialog>
@@ -44,7 +44,7 @@ When using the `title` property, the framework renders it as `<h1>` automaticall
 <Dialog ariaLabelledBy="dlgTitle">
   <customHeader>
     <Toolbar>
-      <Title id="dlgTitle" text="Confirm Deletion" level="H1"/>
+      <Title id="dlgTitle" text="{i18n>confirmDeletionTitle}" level="H1"/>
     </Toolbar>
   </customHeader>
 </Dialog>
@@ -60,7 +60,7 @@ containing a `Title` with an explicit `level`:
 <Panel accessibleRole="Region">
   <headerToolbar>
     <Toolbar>
-      <Title level="H3" text="Shipping Details"/>
+      <Title level="H3" text="{i18n>shippingDetailsTitle}"/>
     </Toolbar>
   </headerToolbar>
   ...
@@ -70,3 +70,8 @@ containing a `Title` with an explicit `level`:
 ## Available values
 
 `H1` · `H2` · `H3` · `H4` · `H5` · `H6` · `Auto` (avoid — use explicit levels)
+
+## i18n bindings
+
+All snippets above use `{i18n>...}` for user-facing strings — bind every UI text to
+the resource model, never hard-code English literals in the view.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/heading.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/heading.md
@@ -1,0 +1,72 @@
+# Heading Levels
+
+Heading hierarchy lets screen reader users scan the page structure and jump between
+sections. Missing or skipped heading levels break this navigation.
+
+**Rule: every `<Title>` used as a heading must have an explicit `level` property set.**
+
+**Wrong:**
+```xml
+<Title text="Order Details"/>
+```
+
+**Correct:**
+```xml
+<Title level="H1" text="Order Details"/>    <!-- page title -->
+<Title level="H2" text="Line Items"/>       <!-- section header -->
+<Title level="H3" text="Item Notes"/>       <!-- subsection -->
+```
+
+## Heading hierarchy rules
+
+- Each page should have exactly one `H1` — the page title.
+- Section headers = `H2`, subsection headers = `H3`, and so on.
+- **Never skip levels** — H1 → H3 with no H2 breaks the document outline and
+  confuses AT users navigating by heading.
+
+## `sap.m.Dialog` heading level
+
+When using the `title` property, the framework renders it as `<h1>` automatically — no extra configuration needed. When using `customHeader` or `showHeader: false`, set `level: TitleLevel.H1` explicitly on the `Title` control.
+
+**Wrong:**
+```xml
+<Dialog>
+  <customHeader>
+    <Toolbar>
+      <Title id="dlgTitle" text="Confirm Deletion"/>
+    </Toolbar>
+  </customHeader>
+</Dialog>
+```
+
+**Correct:**
+```xml
+<Dialog ariaLabelledBy="dlgTitle">
+  <customHeader>
+    <Toolbar>
+      <Title id="dlgTitle" text="Confirm Deletion" level="H1"/>
+    </Toolbar>
+  </customHeader>
+</Dialog>
+```
+
+## `sap.m.Panel` heading level
+
+A `Panel` with `headerText` renders that text as a heading. If the heading level needs
+to be explicitly controlled, replace `headerText` with a `headerToolbar` aggregation
+containing a `Title` with an explicit `level`:
+
+```xml
+<Panel accessibleRole="Region">
+  <headerToolbar>
+    <Toolbar>
+      <Title level="H3" text="Shipping Details"/>
+    </Toolbar>
+  </headerToolbar>
+  ...
+</Panel>
+```
+
+## Available values
+
+`H1` · `H2` · `H3` · `H4` · `H5` · `H6` · `Auto` (avoid — use explicit levels)

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/invisible-message.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/invisible-message.md
@@ -1,0 +1,62 @@
+# Invisible Messaging
+
+Use `sap.ui.core.InvisibleMessage` to announce dynamic state changes to screen reader
+users who would otherwise miss purely visual updates (badge counts, success banners,
+loading indicators, filter results).
+
+## When not to use
+
+- Do not provide information exclusively for AT users — screen reader users should not receive content that sighted users cannot access
+- Do not use it to hide long texts — if the information matters, show it visibly
+
+## Dynamic announcements — `InvisibleMessage`
+
+```js
+sap.ui.define([
+  "sap/ui/core/mvc/Controller",
+  "sap/ui/core/InvisibleMessage",
+  "sap/ui/core/library"
+], function(Controller, InvisibleMessage, library) {
+  "use strict";
+
+  var InvisibleMessageMode = library.InvisibleMessageMode;
+
+  return Controller.extend("my.app.Controller", {
+    onInit: function () {
+      this.oIM = InvisibleMessage.getInstance();
+    },
+
+    onDeleteItems: function () {
+      // ... perform deletion ...
+      this.oIM.announce("3 items deleted", InvisibleMessageMode.Polite);
+    },
+
+    onSubmitError: function () {
+      // ... handle error ...
+      this.oIM.announce(
+        "Submission failed. Please check required fields.",
+        InvisibleMessageMode.Assertive
+      );
+    }
+  });
+});
+```
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `Polite` | Waits for a pause in current speech | Status updates, counts, non-urgent feedback |
+| `Assertive` | Interrupts current speech immediately | Errors, warnings, critical state changes |
+
+## Static ARIA references — `core:InvisibleText`
+
+Use when you need a hidden text node that other controls reference via `ariaLabelledBy`
+or `ariaDescribedBy`, and a visible `<Label>` is not suitable:
+
+```xml
+<core:InvisibleText id="postalLabel" text="Postal code"/>
+<core:InvisibleText id="cityLabel"   text="City"/>
+<Input ariaLabelledBy="postalLabel" value="12345" fieldWidth="35%"/>
+<Input ariaLabelledBy="cityLabel"   value="Sofia"  fieldWidth="35%"/>
+```
+
+Place `InvisibleText` nodes **before** the controls that reference them.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/invisible-message.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/invisible-message.md
@@ -7,7 +7,7 @@ loading indicators, filter results).
 ## When not to use
 
 - Do not provide information exclusively for AT users — screen reader users should not receive content that sighted users cannot access
-- Do not use it to hide long texts — if the information matters, show it visibly
+- Do not use it to hide long texts — if the information matters, show it
 
 ## Dynamic announcements — `InvisibleMessage`
 

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/invisible-message.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/invisible-message.md
@@ -4,6 +4,9 @@ Use `sap.ui.core.InvisibleMessage` to announce dynamic state changes to screen r
 users who would otherwise miss purely visual updates (badge counts, success banners,
 loading indicators, filter results).
 
+All announcement text and static labels below are pulled from the i18n resource
+bundle — bind every UI text to the resource model, never hard-code English literals.
+
 ## When not to use
 
 - Do not provide information exclusively for AT users — screen reader users should not receive content that sighted users cannot access
@@ -24,17 +27,23 @@ sap.ui.define([
   return Controller.extend("my.app.Controller", {
     onInit: function () {
       this.oIM = InvisibleMessage.getInstance();
+      this.oResourceBundle = this.getOwnerComponent()
+        .getModel("i18n")
+        .getResourceBundle();
     },
 
-    onDeleteItems: function () {
+    onDeleteItems: function (iCount) {
       // ... perform deletion ...
-      this.oIM.announce("3 items deleted", InvisibleMessageMode.Polite);
+      this.oIM.announce(
+        this.oResourceBundle.getText("itemsDeletedAnnouncement", [iCount]),
+        InvisibleMessageMode.Polite
+      );
     },
 
     onSubmitError: function () {
       // ... handle error ...
       this.oIM.announce(
-        "Submission failed. Please check required fields.",
+        this.oResourceBundle.getText("submissionFailedAnnouncement"),
         InvisibleMessageMode.Assertive
       );
     }
@@ -53,10 +62,10 @@ Use when you need a hidden text node that other controls reference via `ariaLabe
 or `ariaDescribedBy`, and a visible `<Label>` is not suitable:
 
 ```xml
-<core:InvisibleText id="postalLabel" text="Postal code"/>
-<core:InvisibleText id="cityLabel"   text="City"/>
-<Input ariaLabelledBy="postalLabel" value="12345" fieldWidth="35%"/>
-<Input ariaLabelledBy="cityLabel"   value="Sofia"  fieldWidth="35%"/>
+<core:InvisibleText id="postalLabel" text="{i18n>postalCodeLabel}"/>
+<core:InvisibleText id="cityLabel"   text="{i18n>cityLabel}"/>
+<Input ariaLabelledBy="postalLabel" value="{addr>/postalCode}" fieldWidth="35%"/>
+<Input ariaLabelledBy="cityLabel"   value="{addr>/city}"       fieldWidth="35%"/>
 ```
 
 Place `InvisibleText` nodes **before** the controls that reference them.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/keyboard.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/keyboard.md
@@ -6,17 +6,20 @@ When a Dialog or Popover opens, set which element receives focus. Without this, 
 on the first focusable element, which may not be the right starting point for the task.
 
 ```xml
-<Popover title="Product Details" initialFocus="firstActionBtn">
+<Popover title="{i18n>productDetailsTitle}" initialFocus="firstActionBtn">
   <content>
     <VBox>
-      <Text text="Notebook Basic 15"/>
-      <Button id="firstActionBtn" text="Add to Cart"/>
+      <Text text="{i18n>notebookProductName}"/>
+      <Button id="firstActionBtn" text="{i18n>addToCartButton}"/>
     </VBox>
   </content>
 </Popover>
 ```
 
 Same attribute on `<Dialog initialFocus="elementId">`.
+
+All user-facing strings above are bound via `{i18n>...}` — bind every UI text to the
+resource model, never hard-code English literals in the view.
 
 ## F6 fast navigation
 

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/keyboard.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/keyboard.md
@@ -1,0 +1,68 @@
+# Focus Handling and Keyboard Navigation
+
+## Initial focus — `initialFocus`
+
+When a Dialog or Popover opens, set which element receives focus. Without this, focus lands
+on the first focusable element, which may not be the right starting point for the task.
+
+```xml
+<Popover title="Product Details" initialFocus="firstActionBtn">
+  <content>
+    <VBox>
+      <Text text="Notebook Basic 15"/>
+      <Button id="firstActionBtn" text="Add to Cart"/>
+    </VBox>
+  </content>
+</Popover>
+```
+
+Same attribute on `<Dialog initialFocus="elementId">`.
+
+## F6 fast navigation
+
+F6 / Shift+F6 lets users jump between logical groups. Some standard containers create
+F6 groups automatically — for example, `sap.m.Panel` (the whole panel is one group)
+and `sap.uxap.ObjectPageSection` (each section is a separate group).
+
+**Adding or removing a custom area from the F6 chain**
+
+Standard containers create their own F6 groups automatically. Groups can also be nested —
+pressing F6 inside a nested group moves focus to the next group at that level; if none
+exists, focus moves up to the parent group.
+
+To add a custom area as an F6 group, use the `sap-ui-fastnavgroup` key via `CustomData`:
+
+```xml
+<!-- XML view -->
+<VBox>
+  <customData>
+    <core:CustomData key="sap-ui-fastnavgroup" value="true" writeToDom="true"/>
+  </customData>
+</VBox>
+```
+
+```js
+// Controller / JS
+oControl.data("sap-ui-fastnavgroup", "true", true /* writeToDom */);
+```
+
+To remove a group that a control defines by default, set the value to `"false"`:
+
+```js
+oControl.data("sap-ui-fastnavgroup", "false", true /* writeToDom */);
+```
+
+## Custom interactive elements — `tabindex`
+
+Native HTML elements (button, input, a) are focusable by default. Custom elements
+rendered with a non-interactive tag need explicit `tabindex`:
+
+```html
+<!-- Focusable custom widget -->
+<div role="combobox" tabindex="0" ...> ... </div>
+
+<!-- Remove from tab order but keep programmatically focusable -->
+<div tabindex="-1" ...> ... </div>
+```
+
+Avoid `tabindex` values greater than 0 — they override the natural reading order.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/labeling.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/labeling.md
@@ -1,0 +1,145 @@
+# Labeling and Description
+
+Proper labeling ensures screen readers announce the purpose of every interactive element.
+
+## 1. Input controls — `<Label labelFor>`
+
+**Wrong:** label and input not connected
+```xml
+<Label text="First Name"/>
+<Input id="firstName"/>
+```
+
+**Correct:**
+```xml
+<Label text="First Name" labelFor="firstName"/>
+<Input id="firstName"/>
+```
+
+**Exception — `SimpleForm`:** the framework connects `Label` and `Input` automatically
+based on position. Do NOT set `labelFor` manually inside a `SimpleForm`.
+```xml
+<form:SimpleForm>
+  <Label text="First Name"/>        <!-- labelFor not needed here -->
+  <Input placeholder="Enter name..."/>
+</form:SimpleForm>
+```
+
+## 2. Icon-only buttons — `tooltip`
+
+**Wrong:**
+```xml
+<Button icon="sap-icon://action"/>
+```
+
+**Correct:**
+```xml
+<Button icon="sap-icon://action" tooltip="Perform Action"/>
+```
+
+## 3. Tables — `ariaLabelledBy`
+
+```xml
+<Title id="productsTitle" text="Products"/>
+<Table ariaLabelledBy="productsTitle">
+  ...
+</Table>
+```
+
+## 4. Dialogs — title or `ariaLabelledBy`
+
+Three valid patterns — do not flag any of them:
+
+**Correct A — `title` property:**
+```js
+new Dialog({ title: "Confirm Deletion", content: [...] })
+```
+
+**Correct B — `customHeader` with a `Title`** (framework auto-links it):
+```js
+new Dialog({
+  customHeader: new Toolbar({
+    content: [new Title({ id: "dlgTitle", text: "Confirm Deletion", level: TitleLevel.H1 })]
+  }),
+  content: [...]
+})
+```
+
+**Correct C — `showHeader: false` + explicit `ariaLabelledBy`:**
+```js
+new Dialog({
+  showHeader: false,
+  ariaLabelledBy: "dlgTitle",
+  content: [
+    new Title({ id: "dlgTitle", text: "Confirm Deletion", level: TitleLevel.H1 }),
+    new Text({ text: "This cannot be undone." })
+  ]
+})
+```
+
+**Wrong — no label at all:**
+```js
+new Dialog({
+  showHeader: false,
+  content: [new Text({ text: "This cannot be undone." })]
+})
+```
+
+## 5. Images
+
+```xml
+<!-- Non-decorative: provide alt text -->
+<Image src="product.png" alt="Notebook Basic 15 — front view" decorative="false"/>
+
+<!-- Decorative: no alt needed -->
+<Image src="divider.png" decorative="true"/>
+```
+
+## 6. Standalone icons — `sap.ui.core.Icon`
+
+A standalone `Icon` that is not decorative must have an `alt` property.
+
+**Wrong:**
+```xml
+<core:Icon src="sap-icon://warning"/>
+```
+
+**Correct:**
+```xml
+<!-- Semantic icon — provide alt text -->
+<core:Icon src="sap-icon://warning" alt="Warning"/>
+
+<!-- Decorative icon — mark explicitly so screen readers skip it -->
+<core:Icon src="sap-icon://favorite" decorative="true"/>
+```
+
+Note: for icon-only `sap.m.Button`, use `tooltip` instead — see section 2 above.
+
+## 7. Popovers
+
+```xml
+<Popover title="Product Details" ariaLabelledBy="popTitle">
+  <Text id="popTitle" text="Additional labelling context"/>
+  ...
+</Popover>
+```
+
+For description (additional context):
+```xml
+<Popover title="Product Details" ariaDescribedBy="popDesc">
+  <Text id="popDesc" text="Additional details about this product."/>
+</Popover>
+```
+
+## 8. Static ARIA references — `core:InvisibleText`
+
+Use when two controls share a visual label or when `<Label labelFor>` is not applicable:
+
+```xml
+<core:InvisibleText id="postalLabel" text="Postal code"/>
+<core:InvisibleText id="cityLabel" text="City"/>
+<Input ariaLabelledBy="postalLabel" value="12345" fieldWidth="35%"/>
+<Input ariaLabelledBy="cityLabel" value="Sofia" fieldWidth="35%"/>
+```
+
+Place `InvisibleText` nodes before the controls that reference them.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/labeling.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/labeling.md
@@ -2,17 +2,20 @@
 
 Proper labeling ensures screen readers announce the purpose of every interactive element.
 
+All user-facing text in the snippets below is bound via `{i18n>...}` — bind every UI
+text to the resource model, never hard-code English literals in the view.
+
 ## 1. Input controls — `<Label labelFor>`
 
 **Wrong:** label and input not connected
 ```xml
-<Label text="First Name"/>
+<Label text="{i18n>firstNameLabel}"/>
 <Input id="firstName"/>
 ```
 
 **Correct:**
 ```xml
-<Label text="First Name" labelFor="firstName"/>
+<Label text="{i18n>firstNameLabel}" labelFor="firstName"/>
 <Input id="firstName"/>
 ```
 
@@ -20,8 +23,8 @@ Proper labeling ensures screen readers announce the purpose of every interactive
 based on position. Do NOT set `labelFor` manually inside a `SimpleForm`.
 ```xml
 <form:SimpleForm>
-  <Label text="First Name"/>        <!-- labelFor not needed here -->
-  <Input placeholder="Enter name..."/>
+  <Label text="{i18n>firstNameLabel}"/>        <!-- labelFor not needed here -->
+  <Input placeholder="{i18n>firstNamePlaceholder}"/>
 </form:SimpleForm>
 ```
 
@@ -34,13 +37,13 @@ based on position. Do NOT set `labelFor` manually inside a `SimpleForm`.
 
 **Correct:**
 ```xml
-<Button icon="sap-icon://action" tooltip="Perform Action"/>
+<Button icon="sap-icon://action" tooltip="{i18n>performActionTooltip}"/>
 ```
 
 ## 3. Tables — `ariaLabelledBy`
 
 ```xml
-<Title id="productsTitle" text="Products"/>
+<Title id="productsTitle" text="{i18n>productsTitle}"/>
 <Table ariaLabelledBy="productsTitle">
   ...
 </Table>
@@ -52,14 +55,21 @@ Three valid patterns — do not flag any of them:
 
 **Correct A — `title` property:**
 ```js
-new Dialog({ title: "Confirm Deletion", content: [...] })
+new Dialog({
+  title: oResourceBundle.getText("confirmDeletionTitle"),
+  content: [...]
+})
 ```
 
 **Correct B — `customHeader` with a `Title`** (framework auto-links it):
 ```js
 new Dialog({
   customHeader: new Toolbar({
-    content: [new Title({ id: "dlgTitle", text: "Confirm Deletion", level: TitleLevel.H1 })]
+    content: [new Title({
+      id: "dlgTitle",
+      text: oResourceBundle.getText("confirmDeletionTitle"),
+      level: TitleLevel.H1
+    })]
   }),
   content: [...]
 })
@@ -71,8 +81,12 @@ new Dialog({
   showHeader: false,
   ariaLabelledBy: "dlgTitle",
   content: [
-    new Title({ id: "dlgTitle", text: "Confirm Deletion", level: TitleLevel.H1 }),
-    new Text({ text: "This cannot be undone." })
+    new Title({
+      id: "dlgTitle",
+      text: oResourceBundle.getText("confirmDeletionTitle"),
+      level: TitleLevel.H1
+    }),
+    new Text({ text: oResourceBundle.getText("cannotBeUndoneText") })
   ]
 })
 ```
@@ -81,15 +95,22 @@ new Dialog({
 ```js
 new Dialog({
   showHeader: false,
-  content: [new Text({ text: "This cannot be undone." })]
+  content: [new Text({ text: oResourceBundle.getText("cannotBeUndoneText") })]
 })
+```
+
+`oResourceBundle` is retrieved once per controller, typically in `onInit`:
+```js
+this.oResourceBundle = this.getOwnerComponent()
+  .getModel("i18n")
+  .getResourceBundle();
 ```
 
 ## 5. Images
 
 ```xml
 <!-- Non-decorative: provide alt text -->
-<Image src="product.png" alt="Notebook Basic 15 — front view" decorative="false"/>
+<Image src="product.png" alt="{i18n>notebookProductAlt}" decorative="false"/>
 
 <!-- Decorative: no alt needed -->
 <Image src="divider.png" decorative="true"/>
@@ -107,7 +128,7 @@ A standalone `Icon` that is not decorative must have an `alt` property.
 **Correct:**
 ```xml
 <!-- Semantic icon — provide alt text -->
-<core:Icon src="sap-icon://warning" alt="Warning"/>
+<core:Icon src="sap-icon://warning" alt="{i18n>warningIconAlt}"/>
 
 <!-- Decorative icon — mark explicitly so screen readers skip it -->
 <core:Icon src="sap-icon://favorite" decorative="true"/>
@@ -118,16 +139,16 @@ Note: for icon-only `sap.m.Button`, use `tooltip` instead — see section 2 abov
 ## 7. Popovers
 
 ```xml
-<Popover title="Product Details" ariaLabelledBy="popTitle">
-  <Text id="popTitle" text="Additional labelling context"/>
+<Popover title="{i18n>productDetailsTitle}" ariaLabelledBy="popTitle">
+  <Text id="popTitle" text="{i18n>additionalLabellingContext}"/>
   ...
 </Popover>
 ```
 
 For description (additional context):
 ```xml
-<Popover title="Product Details" ariaDescribedBy="popDesc">
-  <Text id="popDesc" text="Additional details about this product."/>
+<Popover title="{i18n>productDetailsTitle}" ariaDescribedBy="popDesc">
+  <Text id="popDesc" text="{i18n>productDetailsDescription}"/>
 </Popover>
 ```
 
@@ -136,10 +157,10 @@ For description (additional context):
 Use when two controls share a visual label or when `<Label labelFor>` is not applicable:
 
 ```xml
-<core:InvisibleText id="postalLabel" text="Postal code"/>
-<core:InvisibleText id="cityLabel" text="City"/>
-<Input ariaLabelledBy="postalLabel" value="12345" fieldWidth="35%"/>
-<Input ariaLabelledBy="cityLabel" value="Sofia" fieldWidth="35%"/>
+<core:InvisibleText id="postalLabel" text="{i18n>postalCodeLabel}"/>
+<core:InvisibleText id="cityLabel" text="{i18n>cityLabel}"/>
+<Input ariaLabelledBy="postalLabel" value="{addr>/postalCode}" fieldWidth="35%"/>
+<Input ariaLabelledBy="cityLabel" value="{addr>/city}" fieldWidth="35%"/>
 ```
 
 Place `InvisibleText` nodes before the controls that reference them.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/landmark.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/landmark.md
@@ -17,19 +17,22 @@ Examples:
 **Key rule:** A landmark role without a label is also a violation — the AT
 announces "region" but cannot distinguish it from other regions on the same page.
 
+All `*Label` properties in the snippets below are bound via `{i18n>...}` — bind every
+UI text to the resource model, never hard-code English literals in the view.
+
 ## sap.f.DynamicPage
 
 ```xml
 <landmarkInfo>
   <DynamicPageAccessibleLandmarkInfo
     rootRole="Region"
-    rootLabel="Product Details"
+    rootLabel="{i18n>productDetailsLandmark}"
     contentRole="Main"
-    contentLabel="Product Description"
+    contentLabel="{i18n>productDescriptionLandmark}"
     headerRole="Region"
-    headerLabel="Product Header"
+    headerLabel="{i18n>productHeaderLandmark}"
     footerRole="Region"
-    footerLabel="Product Footer"/>
+    footerLabel="{i18n>productFooterLandmark}"/>
 </landmarkInfo>
 ```
 
@@ -39,15 +42,15 @@ announces "region" but cannot distinguish it from other regions on the same page
 <landmarkInfo>
   <PageAccessibleLandmarkInfo
     rootRole="Region"
-    rootLabel="Product Details"
+    rootLabel="{i18n>productDetailsLandmark}"
     contentRole="Main"
-    contentLabel="Product Description"
+    contentLabel="{i18n>productDescriptionLandmark}"
     headerRole="Region"
-    headerLabel="Product Header"
+    headerLabel="{i18n>productHeaderLandmark}"
     subHeaderRole="Region"
-    subHeaderLabel="Category Description"
+    subHeaderLabel="{i18n>categoryDescriptionLandmark}"
     footerRole="Region"
-    footerLabel="Product Footer"/>
+    footerLabel="{i18n>productFooterLandmark}"/>
 </landmarkInfo>
 ```
 
@@ -56,7 +59,7 @@ announces "region" but cannot distinguish it from other regions on the same page
 Use the `accessibleRole` property. The `headerText` serves as the accessible label:
 
 ```xml
-<Panel accessibleRole="Region" headerText="Order Summary">
+<Panel accessibleRole="Region" headerText="{i18n>orderSummaryHeader}">
   ...
 </Panel>
 ```
@@ -67,15 +70,15 @@ Use the `accessibleRole` property. The `headerText` serves as the accessible lab
 <landmarkInfo>
   <ObjectPageAccessibleLandmarkInfo
     rootRole="Region"
-    rootLabel="Order Information"
+    rootLabel="{i18n>orderInformationLandmark}"
     contentRole="Main"
-    contentLabel="Order Details"
+    contentLabel="{i18n>orderDetailsLandmark}"
     headerRole="Region"
-    headerLabel="Order Header"
+    headerLabel="{i18n>orderHeaderLandmark}"
     footerRole="Region"
-    footerLabel="Order Footer"
+    footerLabel="{i18n>orderFooterLandmark}"
     navigationRole="Navigation"
-    navigationLabel="Order navigation"/>
+    navigationLabel="{i18n>orderNavigationLandmark}"/>
 </landmarkInfo>
 ```
 
@@ -85,9 +88,9 @@ Use the `accessibleRole` property. The `headerText` serves as the accessible lab
 <f:FlexibleColumnLayout>
   <f:landmarkInfo>
     <f:FlexibleColumnLayoutAccessibleLandmarkInfo
-      firstColumnLabel="Master list"
-      middleColumnLabel="Item details"
-      lastColumnLabel="Item sub-details"/>
+      firstColumnLabel="{i18n>masterListLandmark}"
+      middleColumnLabel="{i18n>itemDetailsLandmark}"
+      lastColumnLabel="{i18n>itemSubDetailsLandmark}"/>
   </f:landmarkInfo>
 </f:FlexibleColumnLayout>
 ```

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/landmark.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/landmark.md
@@ -1,0 +1,97 @@
+# Landmark API
+
+Landmarks let assistive technology users orient themselves in a page and jump directly
+to named sections via screen reader shortcuts. Without them, users must navigate linearly
+through the entire page.
+
+**When to apply:** Add landmarks only where you can give the area a meaningful, unique
+label. If naming the area helps navigation, add it. If the label would be generic or
+repeated, skip it.
+
+Examples:
+- A `Page` that is the primary container of a view needs landmarks; a `Page` nested
+  inside another `Page` probably does not.
+- Two panels dividing a page into "Order Details" and "Shipping Info" are good candidates
+  for a region landmark.
+
+**Key rule:** A landmark role without a label is also a violation — the AT
+announces "region" but cannot distinguish it from other regions on the same page.
+
+## sap.f.DynamicPage
+
+```xml
+<landmarkInfo>
+  <DynamicPageAccessibleLandmarkInfo
+    rootRole="Region"
+    rootLabel="Product Details"
+    contentRole="Main"
+    contentLabel="Product Description"
+    headerRole="Region"
+    headerLabel="Product Header"
+    footerRole="Region"
+    footerLabel="Product Footer"/>
+</landmarkInfo>
+```
+
+## sap.m.Page
+
+```xml
+<landmarkInfo>
+  <PageAccessibleLandmarkInfo
+    rootRole="Region"
+    rootLabel="Product Details"
+    contentRole="Main"
+    contentLabel="Product Description"
+    headerRole="Region"
+    headerLabel="Product Header"
+    subHeaderRole="Region"
+    subHeaderLabel="Category Description"
+    footerRole="Region"
+    footerLabel="Product Footer"/>
+</landmarkInfo>
+```
+
+## sap.m.Panel
+
+Use the `accessibleRole` property. The `headerText` serves as the accessible label:
+
+```xml
+<Panel accessibleRole="Region" headerText="Order Summary">
+  ...
+</Panel>
+```
+
+## sap.uxap.ObjectPage
+
+```xml
+<landmarkInfo>
+  <ObjectPageAccessibleLandmarkInfo
+    rootRole="Region"
+    rootLabel="Order Information"
+    contentRole="Main"
+    contentLabel="Order Details"
+    headerRole="Region"
+    headerLabel="Order Header"
+    footerRole="Region"
+    footerLabel="Order Footer"
+    navigationRole="Navigation"
+    navigationLabel="Order navigation"/>
+</landmarkInfo>
+```
+
+## sap.f.FlexibleColumnLayout
+
+```xml
+<f:FlexibleColumnLayout>
+  <f:landmarkInfo>
+    <f:FlexibleColumnLayoutAccessibleLandmarkInfo
+      firstColumnLabel="Master list"
+      middleColumnLabel="Item details"
+      lastColumnLabel="Item sub-details"/>
+  </f:landmarkInfo>
+</f:FlexibleColumnLayout>
+```
+
+## Available roles (`sap.ui.core.AccessibleLandmarkRole`)
+
+`Main` · `Navigation` · `Region` · `Banner` · `Complementary` · `Search` · `Form` · `None`

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/reading-order.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/reading-order.md
@@ -1,0 +1,42 @@
+# Reading Order
+
+Screen readers follow DOM order, not visual order. When the two differ — due to CSS,
+FlexBox reordering, or absolute positioning — AT users experience a broken sequence
+that does not match what sighted users see.
+
+## DOM order = reading order
+
+Structure XML so controls appear in logical reading sequence. A label or title must
+appear before the control it describes.
+
+**Wrong:** description placed after the button it belongs to
+```xml
+<Button text="Submit Order"/>
+<Text id="submitHint" text="This will place a binding order."/>
+<!-- ariaDescribedBy="submitHint" would point forward in the DOM -->
+```
+
+**Correct:**
+```xml
+<core:InvisibleText id="submitHint" text="This will place a binding order."/>
+<Button text="Submit Order" ariaDescribedBy="submitHint"/>
+```
+
+## `ariaDescribedBy` / `ariaLabelledBy` forward references
+
+IDs referenced by `ariaDescribedBy` or `ariaLabelledBy` must already exist in the DOM
+when the referencing control renders. If the visible element would appear after the
+control that needs it, use `core:InvisibleText` placed before the control instead.
+
+## Avoid `tabindex > 0`
+
+Setting `tabindex="2"` or higher moves that element to the front of the tab order
+regardless of its DOM position, creating a mismatch between reading order and tab order.
+Use `tabindex="0"` (participates in natural order) or `tabindex="-1"` (skipped by Tab,
+focusable programmatically) only.
+
+## FlexBox / Grid reordering
+
+CSS properties like `order`, `flex-direction: row-reverse`, or `grid-auto-flow` change
+visual position without touching the DOM. Use them only for decorative reordering —
+never to reorder content that conveys meaning or sequence to the user.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/reading-order.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/reading-order.md
@@ -4,6 +4,9 @@ Screen readers follow DOM order, not visual order. When the two differ — due t
 FlexBox reordering, or absolute positioning — AT users experience a broken sequence
 that does not match what sighted users see.
 
+All user-facing strings in the snippets below use `{i18n>...}` bindings — bind every
+UI text to the resource model, never hard-code English literals in the view.
+
 ## DOM order = reading order
 
 Structure XML so controls appear in logical reading sequence. A label or title must
@@ -11,15 +14,15 @@ appear before the control it describes.
 
 **Wrong:** description placed after the button it belongs to
 ```xml
-<Button text="Submit Order"/>
-<Text id="submitHint" text="This will place a binding order."/>
+<Button text="{i18n>submitOrderButton}"/>
+<Text id="submitHint" text="{i18n>submitOrderHint}"/>
 <!-- ariaDescribedBy="submitHint" would point forward in the DOM -->
 ```
 
 **Correct:**
 ```xml
-<core:InvisibleText id="submitHint" text="This will place a binding order."/>
-<Button text="Submit Order" ariaDescribedBy="submitHint"/>
+<core:InvisibleText id="submitHint" text="{i18n>submitOrderHint}"/>
+<Button text="{i18n>submitOrderButton}" ariaDescribedBy="submitHint"/>
 ```
 
 ## `ariaDescribedBy` / `ariaLabelledBy` forward references

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/shortcut.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/shortcut.md
@@ -31,12 +31,16 @@ Add to the `dependents` aggregation of the view root or `Page`:
 ## Step 3 — Wire buttons with the `cmd:` prefix
 
 ```xml
-<Button text="Save"   press="cmd:Save"   tooltip="Save (Ctrl+S)"/>
-<Button text="Delete" press="cmd:Delete" tooltip="Delete (Ctrl+D)"/>
+<Button text="{i18n>saveButton}"   press="cmd:Save"   tooltip="{i18n>saveButtonTooltip}"/>
+<Button text="{i18n>deleteButton}" press="cmd:Delete" tooltip="{i18n>deleteButtonTooltip}"/>
 ```
 
 `press="cmd:Save"` routes through `CommandExecution` to `.onSave`. Both the keyboard
 shortcut and the button click call the same handler — no duplicate logic needed.
+
+Bind `text` and `tooltip` to `{i18n>...}` keys as shown — the tooltip strings should
+include the shortcut hint (e.g. `saveButtonTooltip = "Save (Ctrl+S)"`) so keyboard
+users discover the shortcut. Never hard-code the English literals in the view.
 
 ## Common predefined shortcuts
 

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/shortcut.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/shortcut.md
@@ -1,0 +1,49 @@
+# Keyboard Shortcuts — CommandExecution Pattern
+
+UI5 keyboard shortcuts use `core:CommandExecution` to decouple keyboard bindings from
+button press handlers. Three steps are required.
+
+## Step 1 — Register commands in `manifest.json`
+
+```json
+"sap.ui5": {
+  "commands": {
+    "Save":   { "shortcut": "Ctrl+S" },
+    "Delete": { "shortcut": "Ctrl+D" }
+  }
+}
+```
+
+## Step 2 — Declare `CommandExecution` in the view
+
+Add to the `dependents` aggregation of the view root or `Page`:
+
+```xml
+<Page>
+  <dependents>
+    <core:CommandExecution command="Save"   enabled="true" execute=".onSave"/>
+    <core:CommandExecution command="Delete" enabled="true" execute=".onDelete"/>
+  </dependents>
+  ...
+</Page>
+```
+
+## Step 3 — Wire buttons with the `cmd:` prefix
+
+```xml
+<Button text="Save"   press="cmd:Save"   tooltip="Save (Ctrl+S)"/>
+<Button text="Delete" press="cmd:Delete" tooltip="Delete (Ctrl+D)"/>
+```
+
+`press="cmd:Save"` routes through `CommandExecution` to `.onSave`. Both the keyboard
+shortcut and the button click call the same handler — no duplicate logic needed.
+
+## Common predefined shortcuts
+
+| Command name | Default shortcut |
+|---|---|
+| `Save`   | Ctrl+S |
+| `Delete` | Ctrl+D |
+
+Custom command names and shortcuts can be freely defined in the `commands` section
+of `manifest.json`.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/target-size.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/target-size.md
@@ -1,0 +1,62 @@
+# Minimum Target Size (WCAG 2.5.8)
+
+Touch targets smaller than 24×24 CSS pixels fail WCAG 2.5.8 (AA). The following
+controls can display as links and may need attention depending on the context they
+are used in: `sap.m.Link`, `sap.m.ObjectStatus`, `sap.m.ObjectNumber`,
+`sap.m.ObjectIdentifier`, `sap.m.ObjectMarker`, `sap.m.ObjectAttribute`.
+
+## Inline display — no action needed
+
+When a link is part of a sentence or constrained by the surrounding line-height
+(e.g. inside `FormattedText`), no additional changes are required.
+
+## Display as overlay — `reactiveAreaMode`
+
+Use `reactiveAreaMode="Overlay"` to extend the clickable area of an `ObjectIdentifier`
+link without changing its visual appearance:
+
+```xml
+<List mode="SingleSelect" includeItemInSelection="true">
+  <CustomListItem>
+    <l:VerticalLayout class="sapUiSmallMargin">
+      <Text text="Notebook Basic 15"/>
+      <ObjectIdentifier
+        reactiveAreaMode="Overlay"
+        title="HH-1000"
+        titleActive="true"
+        titlePress=".onIdentifierPress"/>
+    </l:VerticalLayout>
+  </CustomListItem>
+</List>
+```
+
+## Display with spacing — margin class
+
+When link-like controls appear in a toolbar or other dense layout, add
+`class="sapUiTinyMarginBeginEnd"` to provide sufficient spacing around each element:
+
+```xml
+<OverflowToolbar>
+  <ObjectIdentifier
+    class="sapUiTinyMarginBeginEnd"
+    titleActive="true"
+    title="HT-2001"
+    titlePress=".onIdentifierPress"/>
+  <Link
+    class="sapUiTinyMarginBeginEnd"
+    text="10 Portable DVD player"
+    press=".onLinkPress"/>
+  <ObjectStatus
+    class="sapUiTinyMarginBeginEnd"
+    active="true"
+    state="Success"
+    text="Product Shipped"
+    press=".onStatusPress"/>
+  <ObjectNumber
+    class="sapUiTinyMarginBeginEnd"
+    active="true"
+    number="150"
+    unit="EUR"
+    press=".onNumberPress"/>
+</OverflowToolbar>
+```

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/references/target-size.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/references/target-size.md
@@ -5,6 +5,9 @@ controls can display as links and may need attention depending on the context th
 are used in: `sap.m.Link`, `sap.m.ObjectStatus`, `sap.m.ObjectNumber`,
 `sap.m.ObjectIdentifier`, `sap.m.ObjectMarker`, `sap.m.ObjectAttribute`.
 
+All user-facing strings in the snippets below use `{i18n>...}` bindings — bind every
+UI text to the resource model, never hard-code English literals in the view.
+
 ## Inline display — no action needed
 
 When a link is part of a sentence or constrained by the surrounding line-height
@@ -19,10 +22,10 @@ link without changing its visual appearance:
 <List mode="SingleSelect" includeItemInSelection="true">
   <CustomListItem>
     <l:VerticalLayout class="sapUiSmallMargin">
-      <Text text="Notebook Basic 15"/>
+      <Text text="{i18n>notebookProductName}"/>
       <ObjectIdentifier
         reactiveAreaMode="Overlay"
-        title="HH-1000"
+        title="{product>/code}"
         titleActive="true"
         titlePress=".onIdentifierPress"/>
     </l:VerticalLayout>
@@ -40,23 +43,23 @@ When link-like controls appear in a toolbar or other dense layout, add
   <ObjectIdentifier
     class="sapUiTinyMarginBeginEnd"
     titleActive="true"
-    title="HT-2001"
+    title="{product>/code}"
     titlePress=".onIdentifierPress"/>
   <Link
     class="sapUiTinyMarginBeginEnd"
-    text="10 Portable DVD player"
+    text="{product>/name}"
     press=".onLinkPress"/>
   <ObjectStatus
     class="sapUiTinyMarginBeginEnd"
     active="true"
     state="Success"
-    text="Product Shipped"
+    text="{i18n>productShippedStatus}"
     press=".onStatusPress"/>
   <ObjectNumber
     class="sapUiTinyMarginBeginEnd"
     active="true"
-    number="150"
-    unit="EUR"
+    number="{product>/price}"
+    unit="{product>/currency}"
     press=".onNumberPress"/>
 </OverflowToolbar>
 ```

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/README.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/README.md
@@ -1,8 +1,8 @@
 # Skill Test Fixtures
 
 These fixtures are **not** auto-run — there is no test harness, CI job, or assertion
-framework. They are reference cases for manually validating the skill's behaviour:
-invoke `/ui5-best-practices-accessibility` against each file and verify the output
+framework. They are reference cases for manually validating the skill's behavior.
+Invoke `/ui5-best-practices-accessibility` against each file and verify the output
 matches the expectations below.
 
 ## Positive fixtures — skill MUST report these gaps

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/README.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/README.md
@@ -1,6 +1,9 @@
 # Skill Test Fixtures
 
-Run `/ui5-best-practices-accessibility` against each fixture and verify the output matches expectations below.
+These fixtures are **not** auto-run — there is no test harness, CI job, or assertion
+framework. They are reference cases for manually validating the skill's behaviour:
+invoke `/ui5-best-practices-accessibility` against each file and verify the output
+matches the expectations below.
 
 ## Positive fixtures — skill MUST report these gaps
 
@@ -22,6 +25,13 @@ Run `/ui5-best-practices-accessibility` against each fixture and verify the outp
 |---|---|
 | `Title "Order Details"` missing `level` property | Heading levels |
 | Heading jump: H1 → H3 with no H2 | Heading levels |
+
+### `gap-keyboard.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `VBox#filterRegion` — distinct logical region without `sap-ui-fastnavgroup` CustomData | Focus & keyboard |
+| `Input` with `tabindex="3"` CustomData — value greater than 0 overrides natural reading order | Focus & keyboard |
+| `Dialog#confirmDialog` — multiple focusable elements and no `initialFocus` | Focus & keyboard |
 
 ### `gap-dialog.controller.js`
 | Expected finding | Topic |
@@ -70,9 +80,3 @@ Run `/ui5-best-practices-accessibility` against each fixture and verify the outp
 
 ### `ok-target-size.view.xml`
 - `ObjectIdentifier` (`titleActive`) and `ObjectStatus` (`active`) both have `reactiveAreaMode="Overlay"` → **correct, do not flag**
-
----
-
-## How to run
-
-Run the `ui5-best-practices-accessibility` skill against each fixture file and verify the output matches the expected findings above.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/README.md
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/README.md
@@ -1,0 +1,78 @@
+# Skill Test Fixtures
+
+Run `/ui5-best-practices-accessibility` against each fixture and verify the output matches expectations below.
+
+## Positive fixtures — skill MUST report these gaps
+
+### `gap-landmarks.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `Page` missing `landmarkInfo` | Landmarks |
+| `Panel` missing `accessibleRole` | Landmarks |
+
+### `gap-labeling.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `Input#productName` — `Label` missing `labelFor` | Labeling |
+| `Button` icon-only — missing `tooltip` | Labeling |
+| `Table` missing `ariaLabelledBy` | Labeling |
+
+### `gap-heading-levels.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `Title "Order Details"` missing `level` property | Heading levels |
+| Heading jump: H1 → H3 with no H2 | Heading levels |
+
+### `gap-dialog.controller.js`
+| Expected finding | Topic |
+|---|---|
+| `Dialog` with `showHeader:false` and no `ariaLabelledBy` | Labeling |
+
+### `gap-shortcut.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `Button "Save"` and `Button "Delete"` — no `CommandExecution`, no `cmd:` prefix | Keyboard shortcuts |
+
+### `gap-invisible-message.controller.js`
+| Expected finding | Topic |
+|---|---|
+| `onSaveSuccess` — MessageStrip added dynamically with no `InvisibleMessage.announce()` | Invisible messaging |
+| `onSubmitError` — error shown visually only, no assertive announcement | Invisible messaging |
+
+### `gap-reading-order.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `FlexBox direction="RowReverse"` — DOM order differs from visual order | Reading order |
+| `Input ariaDescribedBy="lateNote"` — referenced ID appears after the control in DOM | Reading order |
+
+### `gap-target-size.view.xml`
+| Expected finding | Topic |
+|---|---|
+| `ObjectIdentifier` inside `ColumnListItem` without `reactiveAreaMode` | Target size |
+| `ObjectStatus` inside `ColumnListItem` without `reactiveAreaMode` | Target size |
+
+---
+
+## Negative fixtures — skill MUST NOT report false positives
+
+### `ok-all-correct.view.xml`
+- Complete, correctly implemented view — **skill must return "No accessibility gaps found"**
+- Covers: landmarks, SimpleForm labels, heading levels, table title, icon button tooltip, CommandExecution
+
+### `ok-simpleform.view.xml`
+- `Label` + `Input` inside `SimpleForm` without `labelFor` → **correct, do not flag**
+
+### `ok-dialog.controller.js`
+- `Dialog` with `customHeader` + `Title` and no explicit `ariaLabelledBy` → **correct, framework auto-links it**
+
+### `ok-invisible-message.controller.js`
+- Delete and error handlers each call `InvisibleMessage.announce()` → **correct, do not flag**
+
+### `ok-target-size.view.xml`
+- `ObjectIdentifier` (`titleActive`) and `ObjectStatus` (`active`) both have `reactiveAreaMode="Overlay"` → **correct, do not flag**
+
+---
+
+## How to run
+
+Run the `ui5-best-practices-accessibility` skill against each fixture file and verify the output matches the expected findings above.

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/eval.json
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/eval.json
@@ -1,0 +1,377 @@
+{
+  "version": "1.0",
+  "skill": "ui5-best-practices-accessibility",
+  "skill_prompt_file": "../SKILL.md",
+  "topics": [
+    "Landmarks",
+    "Labeling",
+    "Heading levels",
+    "Focus & keyboard",
+    "Keyboard shortcuts",
+    "Invisible messaging",
+    "Reading order",
+    "Target size"
+  ],
+  "assertion_types": {
+    "report_finding": "Step-3 report contains a finding grouped under `topic` whose body mentions at least one string from `must_mention_any` AND at least one from `must_anchor_on`. All matching is case-insensitive substring.",
+    "report_empty": "Skill output is the negative response (e.g. 'No accessibility gaps found') with zero gap entries.",
+    "finding_count_max": "Total findings under `topic` (or globally if `topic` omitted) is ≤ `max`. Catches over-flagging.",
+    "must_not_mention": "None of the strings in `strings` appear anywhere in the report. Used to assert framework exceptions."
+  },
+  "test_cases": [
+    {
+      "id": "tc-001",
+      "fixture": "fixtures/gap-landmarks.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Landmarks",
+          "must_mention_any": ["landmarkInfo", "PageAccessibleLandmarkInfo"],
+          "must_anchor_on": ["Page"],
+          "description": "Page missing landmarkInfo"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Landmarks",
+          "must_mention_any": ["accessibleRole"],
+          "must_anchor_on": ["Panel"],
+          "description": "Panel missing accessibleRole"
+        },
+        {
+          "id": "a3",
+          "type": "finding_count_max",
+          "topic": "Landmarks",
+          "max": 2,
+          "description": "No more than 2 Landmark findings (no false positives)"
+        }
+      ]
+    },
+    {
+      "id": "tc-002",
+      "fixture": "fixtures/gap-labeling.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Labeling",
+          "must_mention_any": ["labelFor"],
+          "must_anchor_on": ["Input", "Label", "productName"],
+          "description": "Input/Label pair missing labelFor association"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Labeling",
+          "must_mention_any": ["tooltip"],
+          "must_anchor_on": ["Button", "icon"],
+          "description": "Icon-only Button missing tooltip"
+        },
+        {
+          "id": "a3",
+          "type": "report_finding",
+          "topic": "Labeling",
+          "must_mention_any": ["ariaLabelledBy"],
+          "must_anchor_on": ["Table"],
+          "description": "Table missing ariaLabelledBy"
+        },
+        {
+          "id": "a4",
+          "type": "finding_count_max",
+          "topic": "Labeling",
+          "max": 3,
+          "description": "No more than 3 Labeling findings"
+        }
+      ]
+    },
+    {
+      "id": "tc-003",
+      "fixture": "fixtures/gap-heading-levels.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Heading levels",
+          "must_mention_any": ["level", "explicit"],
+          "must_anchor_on": ["Title", "Order Details"],
+          "description": "First Title missing explicit level"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Heading levels",
+          "must_mention_any": ["H1", "H2", "H3", "skip", "jump"],
+          "must_anchor_on": ["heading", "level", "Title"],
+          "description": "Heading hierarchy jumps H1 → H3"
+        },
+        {
+          "id": "a3",
+          "type": "finding_count_max",
+          "topic": "Heading levels",
+          "max": 2,
+          "description": "No more than 2 Heading-level findings"
+        }
+      ]
+    },
+    {
+      "id": "tc-004",
+      "fixture": "fixtures/gap-keyboard.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Focus & keyboard",
+          "must_mention_any": ["sap-ui-fastnavgroup", "fastnavgroup", "fast nav"],
+          "must_anchor_on": ["VBox", "filterRegion"],
+          "description": "VBox region missing fastnavgroup CustomData"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Focus & keyboard",
+          "must_mention_any": ["tabindex"],
+          "must_anchor_on": ["Input", "3", "positive", "greater than 0"],
+          "description": "Input has positive tabindex value"
+        },
+        {
+          "id": "a3",
+          "type": "report_finding",
+          "topic": "Focus & keyboard",
+          "must_mention_any": ["initialFocus"],
+          "must_anchor_on": ["Dialog", "confirmDialog"],
+          "description": "Dialog missing initialFocus"
+        },
+        {
+          "id": "a4",
+          "type": "finding_count_max",
+          "topic": "Focus & keyboard",
+          "max": 3,
+          "description": "No more than 3 Focus & keyboard findings"
+        }
+      ]
+    },
+    {
+      "id": "tc-005",
+      "fixture": "fixtures/gap-dialog.controller.js",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Labeling",
+          "must_mention_any": ["ariaLabelledBy"],
+          "must_anchor_on": ["Dialog", "showHeader"],
+          "description": "Dialog with showHeader:false missing ariaLabelledBy"
+        },
+        {
+          "id": "a2",
+          "type": "finding_count_max",
+          "topic": "Labeling",
+          "max": 1,
+          "description": "No more than 1 Labeling finding"
+        }
+      ]
+    },
+    {
+      "id": "tc-006",
+      "fixture": "fixtures/gap-shortcut.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Keyboard shortcuts",
+          "must_mention_any": ["CommandExecution", "cmd:"],
+          "must_anchor_on": ["Save"],
+          "description": "Save button missing CommandExecution / cmd: prefix"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Keyboard shortcuts",
+          "must_mention_any": ["CommandExecution", "cmd:"],
+          "must_anchor_on": ["Delete"],
+          "description": "Delete button missing CommandExecution / cmd: prefix"
+        },
+        {
+          "id": "a3",
+          "type": "finding_count_max",
+          "topic": "Keyboard shortcuts",
+          "max": 2,
+          "description": "No more than 2 Keyboard shortcut findings"
+        }
+      ]
+    },
+    {
+      "id": "tc-007",
+      "fixture": "fixtures/gap-invisible-message.controller.js",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Invisible messaging",
+          "must_mention_any": ["InvisibleMessage", "announce"],
+          "must_anchor_on": ["onSaveSuccess", "save"],
+          "description": "Save-success handler missing InvisibleMessage.announce()"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Invisible messaging",
+          "must_mention_any": ["InvisibleMessage", "announce", "assertive"],
+          "must_anchor_on": ["onSubmitError", "error", "submit"],
+          "description": "Submit-error handler missing assertive announcement"
+        },
+        {
+          "id": "a3",
+          "type": "finding_count_max",
+          "topic": "Invisible messaging",
+          "max": 2,
+          "description": "No more than 2 Invisible-messaging findings"
+        }
+      ]
+    },
+    {
+      "id": "tc-008",
+      "fixture": "fixtures/gap-reading-order.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Reading order",
+          "must_mention_any": ["RowReverse", "direction", "DOM order", "visual order"],
+          "must_anchor_on": ["FlexBox"],
+          "description": "FlexBox RowReverse breaks DOM/visual order alignment"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Reading order",
+          "must_mention_any": ["ariaDescribedBy", "lateNote", "later in DOM", "after"],
+          "must_anchor_on": ["Input"],
+          "description": "Input's ariaDescribedBy references an ID rendered after it"
+        },
+        {
+          "id": "a3",
+          "type": "finding_count_max",
+          "topic": "Reading order",
+          "max": 2,
+          "description": "No more than 2 Reading-order findings"
+        }
+      ]
+    },
+    {
+      "id": "tc-009",
+      "fixture": "fixtures/gap-target-size.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_finding",
+          "topic": "Target size",
+          "must_mention_any": ["reactiveAreaMode"],
+          "must_anchor_on": ["ObjectIdentifier"],
+          "description": "ObjectIdentifier inside ColumnListItem missing reactiveAreaMode"
+        },
+        {
+          "id": "a2",
+          "type": "report_finding",
+          "topic": "Target size",
+          "must_mention_any": ["reactiveAreaMode"],
+          "must_anchor_on": ["ObjectStatus"],
+          "description": "ObjectStatus inside ColumnListItem missing reactiveAreaMode"
+        },
+        {
+          "id": "a3",
+          "type": "finding_count_max",
+          "topic": "Target size",
+          "max": 2,
+          "description": "No more than 2 Target-size findings"
+        },
+        {
+          "id": "a4",
+          "type": "must_not_mention",
+          "strings": ["ObjectNumber"],
+          "description": "ObjectNumber is non-interactive (no active/press), must not be flagged"
+        }
+      ]
+    },
+    {
+      "id": "tc-010",
+      "fixture": "fixtures/ok-all-correct.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_empty",
+          "description": "Correctly implemented view — skill must return no gaps"
+        }
+      ]
+    },
+    {
+      "id": "tc-011",
+      "fixture": "fixtures/ok-simpleform.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_empty",
+          "description": "Correctly implemented view — skill must return no gaps"
+        },
+        {
+          "id": "a2",
+          "type": "must_not_mention",
+          "strings": ["labelFor"],
+          "description": "SimpleForm exception — Label+Input without labelFor must not be flagged"
+        }
+      ]
+    },
+    {
+      "id": "tc-012",
+      "fixture": "fixtures/ok-dialog.controller.js",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_empty",
+          "description": "Correctly implemented controller — skill must return no gaps"
+        },
+        {
+          "id": "a2",
+          "type": "must_not_mention",
+          "strings": ["ariaLabelledBy"],
+          "description": "customHeader+Title auto-link — explicit ariaLabelledBy not required"
+        }
+      ]
+    },
+    {
+      "id": "tc-013",
+      "fixture": "fixtures/ok-invisible-message.controller.js",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_empty",
+          "description": "Correctly implemented controller — skill must return no gaps"
+        },
+        {
+          "id": "a2",
+          "type": "must_not_mention",
+          "strings": ["missing", "no announcement", "not announced"],
+          "description": "Both handlers already announce via InvisibleMessage — no missing-announcement finding"
+        }
+      ]
+    },
+    {
+      "id": "tc-014",
+      "fixture": "fixtures/ok-target-size.view.xml",
+      "assertions": [
+        {
+          "id": "a1",
+          "type": "report_empty",
+          "description": "Correctly implemented view — skill must return no gaps"
+        },
+        {
+          "id": "a2",
+          "type": "must_not_mention",
+          "strings": ["missing reactiveAreaMode", "without reactiveAreaMode", "no reactiveAreaMode"],
+          "description": "ObjectIdentifier and ObjectStatus already have reactiveAreaMode set"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-dialog.controller.js
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-dialog.controller.js
@@ -1,0 +1,38 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/m/Dialog",
+    "sap/m/Button",
+    "sap/m/Text"
+], function(Controller, Dialog, Button, Text) {
+    "use strict";
+
+    return Controller.extend("my.app.controller.OrderList", {
+
+        onDeletePress: function () {
+            if (!this._oDialog) {
+                // GAP: showHeader:false with no ariaLabelledBy — dialog has no accessible name
+                this._oDialog = new Dialog({
+                    showHeader: false,
+                    content: [
+                        new Text({ text: "Are you sure you want to delete this order?" })
+                    ],
+                    buttons: [
+                        new Button({
+                            text: "Delete",
+                            press: this.onConfirmDelete.bind(this)
+                        }),
+                        new Button({
+                            text: "Cancel",
+                            press: function () { this._oDialog.close(); }.bind(this)
+                        })
+                    ]
+                });
+            }
+            this._oDialog.open();
+        },
+
+        onConfirmDelete: function () {
+            this._oDialog.close();
+        }
+    });
+});

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-heading-levels.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-heading-levels.view.xml
@@ -1,0 +1,18 @@
+<mvc:View
+    controllerName="my.app.controller.Order"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m">
+    <App>
+        <Page title="Order Overview">
+            <content>
+                <!-- GAP: Title has no level property (defaults to Auto) -->
+                <Title text="Order Details"/>
+                <Text text="Review the order information below."/>
+
+                <!-- GAP: jumps from H1 directly to H3, no H2 -->
+                <Title level="H1" text="Annual Report"/>
+                <Title level="H3" text="Revenue Breakdown"/>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-invisible-message.controller.js
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-invisible-message.controller.js
@@ -1,0 +1,40 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/m/MessageStrip"
+], function(Controller, MessageStrip) {
+    "use strict";
+
+    return Controller.extend("my.app.controller.OrderList", {
+
+        onInit: function () {
+            // GAP: InvisibleMessage not instantiated — no screen reader announcements
+        },
+
+        onSaveSuccess: function () {
+            // GAP: MessageStrip added dynamically to the VBox — visible to sighted users
+            // but never announced to screen reader users; InvisibleMessage.announce() missing
+            var oVBox = this.byId("messageContainer");
+            oVBox.addItem(new MessageStrip({
+                text: "Order #12345 was saved successfully.",
+                type: "Success",
+                showCloseButton: true,
+                close: function (oEvent) {
+                    oVBox.removeItem(oEvent.getSource());
+                }
+            }));
+        },
+
+        onSubmitError: function () {
+            // GAP: error MessageStrip added dynamically — AT users receive no announcement
+            var oVBox = this.byId("messageContainer");
+            oVBox.addItem(new MessageStrip({
+                text: "Submission failed. Please check required fields.",
+                type: "Error",
+                showCloseButton: true,
+                close: function (oEvent) {
+                    oVBox.removeItem(oEvent.getSource());
+                }
+            }));
+        }
+    });
+});

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-keyboard.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-keyboard.view.xml
@@ -1,0 +1,42 @@
+<mvc:View
+    controllerName="my.app.controller.Main"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns:core="sap.ui.core"
+    xmlns="sap.m">
+    <App>
+        <Page title="Order Details" id="mainPage">
+            <content>
+                <!-- GAP: distinct logical region (toolbar + filter strip) without sap-ui-fastnavgroup CustomData, so F6 users cannot jump to it as its own group -->
+                <VBox id="filterRegion">
+                    <Toolbar>
+                        <Title text="Filters" level="H2"/>
+                        <ToolbarSpacer/>
+                        <Button icon="sap-icon://filter" tooltip="Apply filter"/>
+                    </Toolbar>
+                    <HBox>
+                        <Input placeholder="Customer"/>
+                        <!-- GAP: tabindex greater than 0 overrides the natural reading order -->
+                        <Input placeholder="Order number">
+                            <customData>
+                                <core:CustomData key="tabindex" value="3" writeToDom="true"/>
+                            </customData>
+                        </Input>
+                    </HBox>
+                </VBox>
+
+                <!-- GAP: Dialog has multiple focusable elements but no initialFocus, so focus lands on the first focusable element (the close button) instead of the primary action -->
+                <Dialog id="confirmDialog" title="Confirm deletion">
+                    <content>
+                        <Text text="Delete the selected order? This cannot be undone."/>
+                    </content>
+                    <beginButton>
+                        <Button id="confirmDeleteBtn" text="Delete" type="Reject" press=".onConfirmDelete"/>
+                    </beginButton>
+                    <endButton>
+                        <Button id="cancelBtn" text="Cancel" press=".onCancel"/>
+                    </endButton>
+                </Dialog>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-labeling.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-labeling.view.xml
@@ -1,0 +1,33 @@
+<mvc:View
+    controllerName="my.app.controller.Products"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m">
+    <App>
+        <Page title="Products">
+            <content>
+                <!-- GAP: Label not connected to Input via labelFor -->
+                <Label text="Product Name"/>
+                <Input id="productName" placeholder="Enter name..."/>
+
+                <!-- GAP: icon-only Button has no tooltip -->
+                <Button icon="sap-icon://save" press=".onSave"/>
+
+                <!-- GAP: Table has no ariaLabelledBy -->
+                <Table id="productsTable">
+                    <columns>
+                        <Column><Text text="Name"/></Column>
+                        <Column><Text text="Price"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="Notebook Basic 15"/>
+                                <Text text="499 EUR"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-landmarks.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-landmarks.view.xml
@@ -1,0 +1,18 @@
+<mvc:View
+    controllerName="my.app.controller.Main"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m">
+    <App>
+        <!-- GAP: Page has no landmarkInfo at all -->
+        <Page title="Product Details" id="mainPage">
+            <content>
+                <!-- GAP: Panel has no accessibleRole -->
+                <Panel headerText="Order Summary" id="orderPanel">
+                    <content>
+                        <Text text="Order #12345"/>
+                    </content>
+                </Panel>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-reading-order.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-reading-order.view.xml
@@ -1,0 +1,33 @@
+<mvc:View
+    controllerName="my.app.controller.ProductDetails"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core">
+    <App>
+        <Page title="Product Details">
+            <content>
+                <!--
+                    GAP 1: FlexBox with direction="RowReverse" — controls are visually
+                    reversed (Price appears left, Name appears right) but DOM order is
+                    Name first, Price second. Screen readers announce Name → Price while
+                    sighted users see Price → Name.
+                -->
+                <FlexBox direction="RowReverse">
+                    <items>
+                        <Text id="productName" text="Notebook Basic 15"/>
+                        <Text id="productPrice" text="€ 1,299.00"/>
+                    </items>
+                </FlexBox>
+
+                <!--
+                    GAP 2: ariaDescribedBy points to "lateNote" which appears AFTER
+                    this Input in the DOM — the description text has not yet been
+                    rendered when the Input is announced by screen readers.
+                -->
+                <Input ariaDescribedBy="lateNote" placeholder="Enter quantity"/>
+                <Text text="Some other content"/>
+                <core:InvisibleText id="lateNote" text="Enter a number between 1 and 99"/>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-shortcut.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-shortcut.view.xml
@@ -1,0 +1,21 @@
+<mvc:View
+    controllerName="my.app.controller.OrderActions"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core">
+    <App>
+        <Page title="Order Actions">
+            <dependents>
+                <!-- GAP: Save and Delete buttons have keyboard shortcuts implied by their
+                     names, but no CommandExecution is declared and no cmd: prefix is used.
+                     Users cannot trigger these actions via Ctrl+S / Ctrl+D. -->
+            </dependents>
+            <content>
+                <VBox class="sapUiSmallMargin">
+                    <Button text="Save" press=".onSave" tooltip="Save"/>
+                    <Button text="Delete" press=".onDelete" tooltip="Delete"/>
+                </VBox>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-target-size.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/gap-target-size.view.xml
@@ -1,0 +1,33 @@
+<mvc:View
+    controllerName="my.app.controller.ProductList"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m">
+    <App>
+        <Page title="Products">
+            <content>
+                <Title id="productsTitle" level="H1" text="Products"/>
+                <!--
+                    GAP: ObjectStatus and ObjectIdentifier inside a ColumnListItem
+                    with no reactiveAreaMode set. In a dense table layout the tap/click
+                    target for these inline interactive controls is too small for touch users.
+                -->
+                <Table ariaLabelledBy="productsTitle">
+                    <columns>
+                        <Column><Text text="Product"/></Column>
+                        <Column><Text text="Status"/></Column>
+                        <Column><Text text="Price"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem type="Navigation">
+                            <cells>
+                                <ObjectIdentifier title="Notebook Basic 15" text="HT-1000" titleActive="true"/>
+                                <ObjectStatus text="Available" state="Success" active="true"/>
+                                <ObjectNumber number="1,299" unit="EUR"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-all-correct.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-all-correct.view.xml
@@ -1,0 +1,72 @@
+<mvc:View
+    controllerName="my.app.controller.ProductDetails"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core"
+    xmlns:form="sap.ui.layout.form">
+    <App>
+        <!--
+            GOLDEN FIXTURE — everything correctly implemented.
+            Running acc-guide against this file should return "No accessibility gaps found."
+
+            Covers:
+            - Page with full landmarkInfo (roles + labels)
+            - Title with explicit level
+            - SimpleForm (no labelFor needed)
+            - Table with ariaLabelledBy
+            - Icon-only Button with tooltip
+            - CommandExecution for keyboard shortcuts
+        -->
+        <Page title="Product Details" id="mainPage">
+            <dependents>
+                <core:CommandExecution command="Save"   enabled="true" execute=".onSave"/>
+                <core:CommandExecution command="Delete" enabled="true" execute=".onDelete"/>
+            </dependents>
+            <landmarkInfo>
+                <PageAccessibleLandmarkInfo
+                    rootRole="Region"
+                    rootLabel="Product Details"
+                    contentRole="Main"
+                    contentLabel="Product Information"
+                    headerRole="Region"
+                    headerLabel="Product Header"
+                    footerRole="Region"
+                    footerLabel="Product Actions"/>
+            </landmarkInfo>
+            <content>
+                <Title level="H2" text="General Information"/>
+
+                <form:SimpleForm editable="true">
+                    <Label text="Product Name"/>
+                    <Input id="productName" placeholder="Enter product name..."/>
+                    <Label text="Category"/>
+                    <Input id="category" placeholder="Enter category..."/>
+                </form:SimpleForm>
+
+                <Title id="specTitle" level="H2" text="Specifications"/>
+                <Table ariaLabelledBy="specTitle">
+                    <columns>
+                        <Column><Text text="Property"/></Column>
+                        <Column><Text text="Value"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="Weight"/>
+                                <Text text="1.5 kg"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </content>
+            <footer>
+                <OverflowToolbar>
+                    <ToolbarSpacer/>
+                    <Button text="Save"   press="cmd:Save"   tooltip="Save (Ctrl+S)"/>
+                    <Button text="Delete" press="cmd:Delete" tooltip="Delete (Ctrl+D)"/>
+                    <Button icon="sap-icon://action-settings" tooltip="More Options"/>
+                </OverflowToolbar>
+            </footer>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-dialog.controller.js
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-dialog.controller.js
@@ -1,0 +1,48 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/m/Dialog",
+    "sap/m/Title",
+    "sap/ui/core/library",
+    "sap/m/Toolbar",
+    "sap/m/Button",
+    "sap/m/Text"
+], function(Controller, Dialog, Title, coreLibrary, Toolbar, Button, Text) {
+    "use strict";
+
+    var TitleLevel = coreLibrary.TitleLevel;
+
+    return Controller.extend("my.app.controller.OrderList", {
+
+        onDeletePress: function () {
+            if (!this._oDialog) {
+                // CORRECT: customHeader with Title (level H1) — framework automatically links
+                // the Title to the dialog via aria-labelledby, no explicit association needed
+                this._oDialog = new Dialog({
+                    customHeader: new Toolbar({
+                        content: [
+                            new Title({ text: "Confirm Deletion", level: TitleLevel.H1 })
+                        ]
+                    }),
+                    content: [
+                        new Text({ text: "Are you sure you want to delete this order?" })
+                    ],
+                    buttons: [
+                        new Button({
+                            text: "Delete",
+                            press: this.onConfirmDelete.bind(this)
+                        }),
+                        new Button({
+                            text: "Cancel",
+                            press: function () { this._oDialog.close(); }.bind(this)
+                        })
+                    ]
+                });
+            }
+            this._oDialog.open();
+        },
+
+        onConfirmDelete: function () {
+            this._oDialog.close();
+        }
+    });
+});

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-invisible-message.controller.js
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-invisible-message.controller.js
@@ -1,0 +1,56 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/m/MessageStrip",
+    "sap/ui/core/InvisibleMessage",
+    "sap/ui/core/library"
+], function(Controller, MessageStrip, InvisibleMessage, library) {
+    "use strict";
+
+    var InvisibleMessageMode = library.InvisibleMessageMode;
+
+    return Controller.extend("my.app.controller.OrderList", {
+
+        onInit: function () {
+            // CORRECT: InvisibleMessage singleton obtained once on init
+            this.oInvisibleMessage = InvisibleMessage.getInstance();
+        },
+
+        onSaveSuccess: function () {
+            // CORRECT: MessageStrip added dynamically AND announced to screen reader users
+            var sText = "Order #12345 was saved successfully.";
+            var sType = "Success";
+            var oVBox = this.byId("messageContainer");
+            oVBox.addItem(new MessageStrip({
+                text: sText,
+                type: sType,
+                showCloseButton: true,
+                close: function (oEvent) {
+                    oVBox.removeItem(oEvent.getSource());
+                }
+            }));
+            this.oInvisibleMessage.announce(
+                "New message of type " + sType + " " + sText,
+                InvisibleMessageMode.Polite
+            );
+        },
+
+        onSubmitError: function () {
+            // CORRECT: error MessageStrip added dynamically and announced assertively
+            var sText = "Submission failed. Please check required fields.";
+            var sType = "Error";
+            var oVBox = this.byId("messageContainer");
+            oVBox.addItem(new MessageStrip({
+                text: sText,
+                type: sType,
+                showCloseButton: true,
+                close: function (oEvent) {
+                    oVBox.removeItem(oEvent.getSource());
+                }
+            }));
+            this.oInvisibleMessage.announce(
+                "New message of type " + sType + " " + sText,
+                InvisibleMessageMode.Assertive
+            );
+        }
+    });
+});

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-simpleform.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-simpleform.view.xml
@@ -1,0 +1,28 @@
+<mvc:View
+    controllerName="my.app.controller.NewOrder"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m"
+    xmlns:form="sap.ui.layout.form">
+    <App>
+        <Page title="New Order">
+            <landmarkInfo>
+                <PageAccessibleLandmarkInfo
+                    rootRole="Region"
+                    rootLabel="New Order Form"
+                    contentRole="Main"
+                    contentLabel="Order Details"/>
+            </landmarkInfo>
+            <content>
+                <form:SimpleForm editable="true">
+                    <!-- CORRECT: inside SimpleForm, labelFor is not needed -->
+                    <!-- The framework connects Label and Input automatically by position -->
+                    <Label text="Product Name"/>
+                    <Input id="productName" placeholder="Enter product name..."/>
+
+                    <Label text="Quantity"/>
+                    <Input id="quantity" placeholder="Enter quantity..."/>
+                </form:SimpleForm>
+            </content>
+        </Page>
+    </App>
+</mvc:View>

--- a/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-target-size.view.xml
+++ b/plugins/ui5/skills/ui5-best-practices-accessibility/tests/fixtures/ok-target-size.view.xml
@@ -1,0 +1,41 @@
+<mvc:View
+    controllerName="my.app.controller.ProductList"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m">
+    <App>
+        <Page title="Products">
+            <content>
+                <Title id="productsTitle" level="H1" text="Products"/>
+                <!--
+                    CORRECT: reactiveAreaMode set on ObjectIdentifier and ObjectStatus
+                    ensures the touch target meets the minimum 3rem requirement even
+                    in a dense table layout.
+                -->
+                <Table ariaLabelledBy="productsTitle">
+                    <columns>
+                        <Column><Text text="Product"/></Column>
+                        <Column><Text text="Status"/></Column>
+                        <Column><Text text="Price"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem type="Navigation">
+                            <cells>
+                                <ObjectIdentifier
+                                    title="Notebook Basic 15"
+                                    text="HT-1000"
+                                    titleActive="true"
+                                    reactiveAreaMode="Overlay"/>
+                                <ObjectStatus
+                                    text="Available"
+                                    state="Success"
+                                    active="true"
+                                    reactiveAreaMode="Overlay"/>
+                                <ObjectNumber number="1,299" unit="EUR"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </content>
+        </Page>
+    </App>
+</mvc:View>


### PR DESCRIPTION
Adds a new skill for UI5 accessibility best practices covering keyboard navigation, labelling, landmarks, heading levels, reading order, target size, shortcuts, and invisible messages. Includes reference documentation and test fixtures for each topic.

JIRA: FIORITECHP1-35629