### PR TITLE
feat(ui5): Add Smart & MDC Controls best practices skill

### DIFF
--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -42,6 +42,15 @@ Development guidelines for UI Integration Cards (also known as UI5 Integration C
 - **i18n** - Bind all user-facing strings to the i18n model; never hardcode
 - **Actions** - Use the `actions` property for links and interactions; never inline `<a>` tags or hand-roll URL handlers
 
+#### ui5-best-practices-mdc
+
+Development guidelines for `sap.ui.mdc` model-driven controls with OData V4 and JSON models (SAPUI5 1.136+ LTS):
+
+- **Delegate pattern** - Base delegates, `fetchProperties`, `updateBindingInfo`, PropertyInfo structure
+- **Per-control references** - FilterBar, Chart, Field, FilterField, ValueHelp, Link, MultiValueField
+- **JSON model support** - Custom delegates, TypeMap registration, manual PropertyInfo
+- **Core rules** - Delegate configuration, `p13nMode`, condition handling, type namespaces
+
 #### ui5-best-practices-opa5
 
 Guidelines and debugging workflow for OPA5 integration tests:
@@ -50,6 +59,15 @@ Guidelines and debugging workflow for OPA5 integration tests:
 - **TestRecorder tooling** - Temporary `sap.ui.testrecorder.ControlTree` integration to inspect the live control tree and generate reliable OPA5 snippets (UI5 ≥ 1.147)
 - **Page object organization** - Placement of actions and assertions across views
 - **App teardown** - Cleanup patterns in OPA5 journey tests
+
+#### ui5-best-practices-smart-controls
+
+Development guidelines for `sap.ui.comp` annotation-driven smart controls with OData V2 (SAPUI5 1.136+ LTS):
+
+- **Per-control references** - SmartField, SmartForm, SmartFilterBar, SmartChart, SmartLink, SmartMultiInput, FilterBar, ValueHelpDialog
+- **Core rules** - Annotation requirements, `entitySet` binding, `initialise` event, SmartForm hierarchy
+- **Selection matrix** - When to use each smart control vs. alternatives
+- **Common errors** - Annotation mistakes, rendering issues, binding problems
 
 #### ui5-best-practices-tables
 
@@ -63,24 +81,6 @@ Authoritative development guidelines for all UI5 table controls (SAPUI5 1.136+ L
 - **Drag & drop** - Correct `DragDropInfo` and `DragInfo`/`DropInfo` configuration
 - **Personalization** - `sap.m.p13n.Engine` integration
 - **Cell templates & alignment** - Type-based alignment and model type namespace rules
-
-#### ui5-best-practices-smart-controls
-
-Development guidelines for `sap.ui.comp` annotation-driven smart controls with OData V2 (SAPUI5 1.136+ LTS):
-
-- **Per-control references** - SmartField, SmartForm, SmartFilterBar, SmartChart, SmartLink, SmartMultiInput, FilterBar, ValueHelpDialog
-- **Core rules** - Annotation requirements, `entitySet` binding, `initialise` event, SmartForm hierarchy
-- **Selection matrix** - When to use each smart control vs. alternatives
-- **Common errors** - Annotation mistakes, rendering issues, binding problems
-
-#### ui5-best-practices-mdc
-
-Development guidelines for `sap.ui.mdc` model-driven controls with OData V4 and JSON models (SAPUI5 1.136+ LTS):
-
-- **Delegate pattern** - Base delegates, `fetchProperties`, `updateBindingInfo`, PropertyInfo structure
-- **Per-control references** - FilterBar, Chart, Field, FilterField, ValueHelp, Link, MultiValueField
-- **JSON model support** - Custom delegates, TypeMap registration, manual PropertyInfo
-- **Core rules** - Delegate configuration, `p13nMode`, condition handling, type namespaces
 
 ---
 

--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -64,6 +64,24 @@ Authoritative development guidelines for all UI5 table controls (SAPUI5 1.136+ L
 - **Personalization** - `sap.m.p13n.Engine` integration
 - **Cell templates & alignment** - Type-based alignment and model type namespace rules
 
+#### ui5-best-practices-smart-controls
+
+Development guidelines for `sap.ui.comp` annotation-driven smart controls with OData V2 (SAPUI5 1.136+ LTS):
+
+- **Per-control references** - SmartField, SmartForm, SmartFilterBar, SmartChart, SmartLink, SmartMultiInput, FilterBar, ValueHelpDialog
+- **Core rules** - Annotation requirements, `entitySet` binding, `initialise` event, SmartForm hierarchy
+- **Selection matrix** - When to use each smart control vs. alternatives
+- **Common errors** - Annotation mistakes, rendering issues, binding problems
+
+#### ui5-best-practices-mdc
+
+Development guidelines for `sap.ui.mdc` model-driven controls with OData V4 and JSON models (SAPUI5 1.136+ LTS):
+
+- **Delegate pattern** - Base delegates, `fetchProperties`, `updateBindingInfo`, PropertyInfo structure
+- **Per-control references** - FilterBar, Chart, Field, FilterField, ValueHelp, Link, MultiValueField
+- **JSON model support** - Custom delegates, TypeMap registration, manual PropertyInfo
+- **Core rules** - Delegate configuration, `p13nMode`, condition handling, type namespaces
+
 ---
 
 ## Installation

--- a/plugins/ui5/skills/ui5-best-practices-mdc/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: ui5-best-practices-mdc
+description: |
+    UI5 MDC (Model-Driven Controls) best practices and authoritative development guidelines for OData V4 delegate-based controls. Use when the user asks to "create an MDC FilterBar", "implement MDC Chart", "add MDC Field", "use MDC FilterField", "implement ValueHelp", "add MDC Link", "MDC MultiValueField", "sap.ui.mdc", "delegate pattern", "fetchProperties", "OData V4 freestyle controls", "MDC personalization", "p13nMode", "PropertyInfo", "MDC delegate", "FilterBarDelegate", "ChartDelegate", "ValueHelpDelegate", "LinkDelegate", "MDC field not rendering", "MDC chart not binding", "MDC conditions", "Condition.createCondition", "MDC Table delegate", or is writing any UI5 freestyle application using OData V4 with model-driven controls from sap.ui.mdc. Covers: delegate pattern, PropertyInfo structure, mandatory rules, common error patterns, and per-control API reference for FilterBar, Chart, Field, FilterField, ValueHelp, Link, and MultiValueField.
+
+    Keywords: sap.ui.mdc, MDC, FilterBar, Chart, Field, FilterField, ValueHelp, Link, MultiValueField, delegate, fetchProperties, updateBindingInfo, PropertyInfo, OData V4, JSON model, JSONModel, custom delegate, TypeMap, DefaultTypeMap, base delegate, non-OData, addItem, getFilters, p13nMode, autoBindOnInit, conditions, TypeMap, FieldBase, FilterBarBase, ChartDelegate, ValueHelpDelegate, LinkDelegate, FilterBarDelegate, MultiValueFieldDelegate, Condition.createCondition
+---
+
+# UI5 MDC Controls Best Practices
+
+Apply these guidelines whenever generating, reviewing, or troubleshooting MDC control code in freestyle applications using OData V4 services.
+
+**UI5 version baseline:** SAPUI5 1.136+ LTS. All features mentioned are available from this version unless noted.
+
+This skill complements `ui5-best-practices`. General rules (module loading, data binding types, CSP, TypeScript events) apply alongside these control-specific guidelines.
+
+## When to load each reference
+
+| Trigger                                               | Load                                                                                                                     |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Working on or planning a `sap.ui.mdc.FilterBar`       | [`references/mdc-filter-bar.md`](references/mdc-filter-bar.md)                                                           |
+| Working on or planning a `sap.ui.mdc.Chart`           | [`references/mdc-chart.md`](references/mdc-chart.md)                                                                     |
+| Working on or planning a `sap.ui.mdc.Field`           | [`references/mdc-field.md`](references/mdc-field.md)                                                                     |
+| Working on or planning a `sap.ui.mdc.FilterField`     | [`references/mdc-filter-field.md`](references/mdc-filter-field.md)                                                       |
+| Working on or planning a `sap.ui.mdc.ValueHelp`       | [`references/mdc-value-help.md`](references/mdc-value-help.md)                                                           |
+| Working on or planning a `sap.ui.mdc.Link`            | [`references/mdc-link.md`](references/mdc-link.md)                                                                       |
+| Working on or planning a `sap.ui.mdc.MultiValueField` | [`references/mdc-multi-value-field.md`](references/mdc-multi-value-field.md)                                             |
+| Using MDC controls with JSON model (non-OData)        | [`references/mdc-json-delegates.md`](references/mdc-json-delegates.md)                                                   |
+| Working on or planning a `sap.ui.mdc.Table`           | See `ui5-best-practices-tables` skill, [`references/mdc-table.md`](../ui5-best-practices-tables/references/mdc-table.md) |
+
+Load before producing any output. Do not work from memory.
+
+---
+
+## The Delegate Pattern
+
+All MDC controls use a **delegate** to decouple the control from data-source-specific logic. App developers must:
+
+1. Specify the delegate in XML: `delegate="{name: 'my/app/delegate/MyDelegate', payload: {entitySet: 'Products'}}"`
+2. Implement the delegate module extending the appropriate base delegate
+3. Override key methods (at minimum `fetchProperties`)
+
+**Base delegates for OData V4:**
+
+| Control         | Base Delegate                              |
+| --------------- | ------------------------------------------ |
+| Table           | `sap/ui/mdc/odata/v4/TableDelegate`        |
+| FilterBar       | `sap/ui/mdc/odata/v4/FilterBarDelegate`    |
+| Chart           | `sap/ui/mdc/odata/v4/vizChart/Delegate`    |
+| ValueHelp       | `sap/ui/mdc/ValueHelpDelegate`             |
+| Link            | `sap/ui/mdc/LinkDelegate`                  |
+| MultiValueField | `sap/ui/mdc/field/MultiValueFieldDelegate` |
+
+**JSON model usage:** MDC controls also work with JSON models. Extend the base delegates directly (`sap/ui/mdc/TableDelegate`, `sap/ui/mdc/FilterBarDelegate`) — not the OData V4 variants. See [`references/mdc-json-delegates.md`](references/mdc-json-delegates.md) for details.
+
+**PropertyInfo** — the core metadata format returned by `fetchProperties`:
+
+```javascript
+{
+    key: "propertyName",        // Unique identifier (required)
+    label: "Display Label",     // User-visible label (required)
+    dataType: "sap.ui.model.odata.v4.type.String"  // Data type (required)
+}
+```
+
+---
+
+## Core Rules
+
+### Mandatory
+
+- Every MDC control requires a `delegate` property pointing to a valid module path.
+- Implement `fetchProperties` in the delegate returning `PropertyInfo[]` with at minimum: `key`, `label`, `dataType`.
+- Extend the appropriate OData V4 base delegate (see table above) for OData V4 services. For JSON/other models, extend the generic base delegate directly.
+- Use `p13nMode` to enable personalization (Column, Sort, Filter, Group for Table; Item, Sort, Filter, Type for Chart; Item for FilterBar).
+- Use `sap.ui.mdc.condition.Condition.createCondition()` to construct conditions programmatically.
+- Use `sap.ui.model.odata.v4.type.*` types in PropertyInfo `dataType` field for OData V4 models. Use `sap.ui.model.type.*` with JSON models. Register types in the TypeMap.
+- Set `ariaLabelledBy` on FilterBar and Chart for accessibility.
+- Prefer Fiori elements building blocks over freestyle MDC. Use MDC only when Fiori elements is out of scope.
+- Use `get_api_reference` MCP tool to verify control APIs. Use `run_ui5_linter` to validate code.
+
+### Prohibitions
+
+- Do not use MDC controls with OData V2 models. Use Smart controls (`sap.ui.comp`) instead. MDC works with OData V4 and JSON models.
+- Do not access inner controls directly (e.g., inner `sap.chart.Chart` or `sap.m.Table`). Use the delegate or MDC control's public API.
+- Do not omit `key` from PropertyInfo objects (formerly `name`, now deprecated).
+- Do not construct condition objects manually as plain JSON. Always use `Condition.createCondition(operator, values)`.
+- Do not skip delegate implementation for production code (built-in defaults are for demos only).
+- Do not use inline styles or scripts (CSP compliance).
+- Do not use global access (`sap.ui.mdc.FilterBar`). Use `sap.ui.define` or ES6 imports.
+
+---
+
+## Selection Matrix
+
+| Control               | Use when                                                           | Do not use when                                                     |
+| --------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `MDC FilterBar`       | OData V4 or JSON model, delegate-driven filter UI, MDC Table/Chart | OData V2 (use SmartFilterBar), simple search bar                    |
+| `MDC Chart`           | OData V4, delegate-driven chart visualization, drill-down          | OData V2 (use SmartChart), simple static charts, no analytical data |
+| `MDC Field`           | OData V4 or JSON, single field with auto-rendering by data type    | OData V2 (use SmartField), purely custom rendering needed           |
+| `MDC FilterField`     | Inside MDC FilterBar for individual filter conditions              | Standalone filtering outside FilterBar context                      |
+| `MDC ValueHelp`       | OData V4 or JSON, type-ahead + dialog value selection              | OData V2 (use ValueHelpDialog), simple dropdowns without search     |
+| `MDC Link`            | OData V4, semantic object navigation, delegate-driven link targets | OData V2 (use SmartLink), simple static links                       |
+| `MDC MultiValueField` | OData V4 or JSON, multi-value token entry via items aggregation    | OData V2 (use SmartMultiInput), simple single-value fields          |
+
+---
+
+## Common Errors
+
+| Symptom                               | Cause                                                                             | Fix                                                                                            |
+| ------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| "Delegate module could not be loaded" | Wrong path in `delegate` property                                                 | Verify module path matches actual file location in project.                                    |
+| Chart shows no data                   | `fetchProperties` returns wrong PropertyInfo (missing `groupable`/`aggregatable`) | Ensure dimensions have `groupable: true`, measures have `aggregatable: true`.                  |
+| FilterBar fields not appearing        | PropertyInfo missing or `hiddenFilter: true`                                      | Check delegate `fetchProperties` returns properties with correct visibility.                   |
+| Field shows wrong inner control       | `dataType` in PropertyInfo doesn't match expected format                          | Verify `dataType` uses full qualified type name (e.g., `sap.ui.model.odata.v4.type.String`).   |
+| Personalization dialog empty          | `p13nMode` not set or PropertyInfo incomplete                                     | Add `p13nMode="Column,Sort,Filter"` and ensure PropertyInfo has `sortable`/`filterable` flags. |
+| ValueHelp not opening                 | ValueHelp not connected to Field or containers missing                            | Verify `valueHelp` association on Field and that Popover/Dialog containers are defined.        |
+| Conditions not applied to binding     | `updateBindingInfo` not implemented in delegate                                   | Implement `updateBindingInfo` to apply filter conditions to the OData binding.                 |
+| Link always rendered as text          | `fetchLinkType` returns `LinkType.Text` or fails                                  | Implement `fetchLinkType` returning `Popup` or `DirectLink` type.                              |
+
+---
+
+## Performance & Accessibility
+
+### Anti-patterns to avoid
+
+- Loading all PropertyInfo eagerly when only a subset is needed (return minimal set from `fetchProperties`).
+- Not implementing `updateBindingInfo` (conditions are never applied to the data binding).
+- Skipping `p13nMode` configuration (personalization features are disabled by default).
+- Creating large delegate modules (split complex logic into helper modules loaded on demand).
+- Using synchronous operations in delegate methods (all delegate methods should return Promises).
+
+### Accessibility checklist
+
+- Set `ariaLabelledBy` on FilterBar referencing a visible title.
+- Set `ariaLabelledBy` on Chart referencing a visible title.
+- Verify keyboard navigation works for personalization dialogs.
+- Test ValueHelp type-ahead and dialog with screen reader.
+- Ensure all FilterFields have meaningful labels via PropertyInfo `label`.

--- a/plugins/ui5/skills/ui5-best-practices-mdc/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/SKILL.md
@@ -12,8 +12,6 @@ Apply these guidelines whenever generating, reviewing, or troubleshooting MDC co
 
 **UI5 version baseline:** SAPUI5 1.136+ LTS. All features mentioned are available from this version unless noted.
 
-This skill complements `ui5-best-practices`. General rules (module loading, data binding types, CSP, TypeScript events) apply alongside these control-specific guidelines.
-
 ## When to load each reference
 
 | Trigger                                               | Load                                                                                                                     |

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-chart.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-chart.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.Chart
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.Chart
+API: https://ui5.sap.com/#/api/sap.ui.mdc.Chart
 
 ## Delegate pattern
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-chart.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-chart.md
@@ -1,0 +1,95 @@
+# sap.ui.mdc.Chart
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.Chart
+
+## Delegate pattern
+
+`sap.ui.mdc.Chart` uses a delegate for chart initialization and data binding. Extend `sap/ui/mdc/odata/v4/vizChart/Delegate` for OData V4.
+
+Minimal delegate:
+
+```javascript
+sap.ui.define(
+    ["sap/ui/mdc/odata/v4/vizChart/Delegate"],
+    function (ChartDelegate) {
+        const MyChartDelegate = Object.assign({}, ChartDelegate)
+
+        MyChartDelegate.fetchProperties = function (oChart) {
+            return Promise.resolve([
+                {
+                    key: "category",
+                    label: "Category",
+                    dataType: "sap.ui.model.odata.v4.type.String",
+                    groupable: true,
+                    aggregatable: false,
+                    role: "category",
+                },
+                {
+                    key: "revenue",
+                    label: "Revenue",
+                    dataType: "sap.ui.model.odata.v4.type.Decimal",
+                    groupable: false,
+                    aggregatable: true,
+                    role: "axis1",
+                },
+            ])
+        }
+
+        return MyChartDelegate
+    }
+)
+```
+
+## PropertyInfo for Chart
+
+| Field          | Type    | Purpose                                                    |
+| -------------- | ------- | ---------------------------------------------------------- |
+| `key`          | string  | Unique property identifier (required).                     |
+| `label`        | string  | Display label (required).                                  |
+| `dataType`     | string  | Full type name (required).                                 |
+| `groupable`    | boolean | `true` = can be used as dimension.                         |
+| `aggregatable` | boolean | `true` = can be used as measure.                           |
+| `role`         | string  | `"category"`, `"series"`, `"axis1"`, `"axis2"`, `"axis3"`. |
+| `sortable`     | boolean | Enable sorting.                                            |
+| `filterable`   | boolean | Enable filtering.                                          |
+
+## Chart usage
+
+```xml
+<mdc:Chart id="myChart" header="Sales Overview"
+    delegate="{name: 'my/app/delegate/ChartDelegate', payload: {entitySet: 'Sales'}}"
+    p13nMode="Item,Sort,Type" height="400px"
+    filter="filterBar" autoBindOnInit="true">
+    <mdc:items>
+        <mdcChart:Item propertyKey="category" type="groupable" role="category"/>
+        <mdcChart:Item propertyKey="revenue" type="aggregatable" role="axis1"/>
+    </mdc:items>
+</mdc:Chart>
+```
+
+## Key properties
+
+| Property         | Purpose                                                  |
+| ---------------- | -------------------------------------------------------- |
+| `delegate`       | Delegate module path and payload (required).             |
+| `header`         | Chart title.                                             |
+| `height`         | Explicit height (required — chart collapses without it). |
+| `p13nMode`       | Personalization: `Item`, `Sort`, `Filter`, `Type`.       |
+| `filter`         | Association to MDC FilterBar for connected filtering.    |
+| `autoBindOnInit` | Auto-bind data on initialization.                        |
+| `legendVisible`  | Show/hide chart legend.                                  |
+| `noDataText`     | Custom text for empty state.                             |
+
+## Key events
+
+| Event              | Purpose                        |
+| ------------------ | ------------------------------ |
+| `dataLoadComplete` | Inner chart data fully loaded. |
+
+## Troubleshooting
+
+- Chart not visible / height 0: set explicit `height` on Chart (e.g., `"400px"` or `"50vh"`).
+- No data displayed: verify `fetchProperties` returns properties with correct `groupable`/`aggregatable` flags.
+- Chart type unavailable: current data combination doesn't support it; verify dimensions/measures.
+- PersonalizationDialog empty: set `p13nMode` and ensure PropertyInfo has all required flags.
+- FilterBar not applying: verify `filter` association points to correct FilterBar ID.

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-field.md
@@ -1,0 +1,80 @@
+# sap.ui.mdc.Field
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.Field
+
+## Key properties
+
+| Property                | Purpose                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `value`                 | Field value (bindable).                                                       |
+| `additionalValue`       | Description for key/text pairs (bindable).                                    |
+| `display`               | Display mode: `Value`, `Description`, `ValueDescription`, `DescriptionValue`. |
+| `dataType`              | Data type name (determines inner control rendering).                          |
+| `dataTypeConstraints`   | Type constraints (e.g., `{maxLength: 40}`).                                   |
+| `dataTypeFormatOptions` | Format options (e.g., `{groupingEnabled: true}`).                             |
+| `editMode`              | `Display`, `Editable`, `ReadOnly`, `Disabled`.                                |
+| `multipleLines`         | Renders TextArea for multi-line input.                                        |
+| `valueHelp`             | Association to a ValueHelp control.                                           |
+
+## Inner control selection by data type
+
+**Edit mode:**
+
+| Data Type              | Inner Control                                |
+| ---------------------- | -------------------------------------------- |
+| String                 | Input                                        |
+| String (multipleLines) | TextArea                                     |
+| Date                   | DatePicker                                   |
+| DateTimeOffset         | DateTimePicker                               |
+| TimeOfDay              | TimePicker                                   |
+| Boolean                | — (not auto-rendered; use CheckBox manually) |
+| Numeric types          | Input                                        |
+
+**Display mode:** All types render as `sap.m.Text` unless `FieldInfo` is set (renders as Link).
+
+## Field usage
+
+Standalone:
+
+```xml
+<mdc:Field id="nameField" value="{Name}" additionalValue="{Description}"
+    display="DescriptionValue"
+    dataType="sap.ui.model.odata.v4.type.String"
+    editMode="Editable"/>
+```
+
+With ValueHelp:
+
+```xml
+<mdc:Field id="categoryField" value="{CategoryID}" additionalValue="{CategoryName}"
+    display="DescriptionValue"
+    dataType="sap.ui.model.odata.v4.type.String"
+    valueHelp="categoryValueHelp"/>
+
+<mdc:ValueHelp id="categoryValueHelp" .../>
+```
+
+With FieldInfo (renders as Link for navigation):
+
+```xml
+<mdc:Field id="supplierField" value="{SupplierName}">
+    <mdc:fieldInfo>
+        <mdc:Link delegate="{name: 'my/app/delegate/LinkDelegate'}"/>
+    </mdc:fieldInfo>
+</mdc:Field>
+```
+
+## Key events
+
+| Event        | Purpose                                                         |
+| ------------ | --------------------------------------------------------------- |
+| `change`     | Value changed by user. Parameters: `value`, `valid`, `promise`. |
+| `liveChange` | Fired as user types (for Input inner control).                  |
+
+## Troubleshooting
+
+- Wrong inner control rendered: verify `dataType` uses the correct full qualified name.
+- Value help not opening: check `valueHelp` association points to a valid ValueHelp control ID.
+- Display shows key instead of description: set `additionalValue` binding and `display="DescriptionValue"`.
+- Field not editable: check `editMode` property is set to `"Editable"`.
+- Binding type error: ensure `dataType` matches the model's property type (use `sap.ui.model.odata.v4.type.*` for OData V4).

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-field.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.Field
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.Field
+API: https://ui5.sap.com/#/api/sap.ui.mdc.Field
 
 ## Key properties
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-bar.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-bar.md
@@ -1,0 +1,93 @@
+# sap.ui.mdc.FilterBar
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.FilterBar
+
+## Delegate pattern
+
+`sap.ui.mdc.FilterBar` uses a delegate for metadata and filter configuration. Extend `sap/ui/mdc/odata/v4/FilterBarDelegate` for OData V4.
+
+Minimal delegate:
+
+```javascript
+sap.ui.define(
+    ["sap/ui/mdc/odata/v4/FilterBarDelegate"],
+    function (FilterBarDelegate) {
+        const MyFilterBarDelegate = Object.assign({}, FilterBarDelegate)
+
+        MyFilterBarDelegate.fetchProperties = function (oFilterBar) {
+            return Promise.resolve([
+                {
+                    key: "name",
+                    label: "Name",
+                    dataType: "sap.ui.model.odata.v4.type.String",
+                    maxConditions: -1,
+                },
+                {
+                    key: "category",
+                    label: "Category",
+                    dataType: "sap.ui.model.odata.v4.type.String",
+                    maxConditions: -1,
+                },
+                {
+                    key: "price",
+                    label: "Price",
+                    dataType: "sap.ui.model.odata.v4.type.Decimal",
+                    maxConditions: 1,
+                },
+            ])
+        }
+
+        return MyFilterBarDelegate
+    }
+)
+```
+
+## PropertyInfo for FilterBar
+
+| Field           | Type    | Purpose                                |
+| --------------- | ------- | -------------------------------------- |
+| `key`           | string  | Unique property identifier (required). |
+| `label`         | string  | Display label (required).              |
+| `dataType`      | string  | Full type name (required).             |
+| `maxConditions` | number  | `-1` = unlimited, `1` = single value.  |
+| `hiddenFilter`  | boolean | `true` = not shown in FilterBar UI.    |
+| `required`      | boolean | `true` = mandatory filter.             |
+
+## FilterBar usage
+
+```xml
+<mdc:FilterBar id="filterBar"
+    delegate="{name: 'my/app/delegate/FilterBarDelegate', payload: {entitySet: 'Products'}}"
+    p13nMode="Item,Value"
+    showClearButton="true">
+    <mdc:filterItems>
+        <mdc:FilterField propertyKey="name" conditions="{$filters>/conditions/name}"
+            label="Name" maxConditions="-1"/>
+        <mdc:FilterField propertyKey="category" conditions="{$filters>/conditions/category}"
+            label="Category" maxConditions="-1"/>
+    </mdc:filterItems>
+</mdc:FilterBar>
+```
+
+## Connecting to MDC Table or Chart
+
+Use the `filter` association on the Table/Chart pointing to the FilterBar ID:
+
+```xml
+<mdc:FilterBar id="filterBar" .../>
+<mdc:Table id="myTable" filter="filterBar" .../>
+```
+
+## Key events
+
+| Event            | Purpose                              |
+| ---------------- | ------------------------------------ |
+| `search`         | Fired when "Go" button pressed.      |
+| `filtersChanged` | Fired when filter conditions change. |
+
+## Troubleshooting
+
+- No filter fields appearing: verify `fetchProperties` returns properties and `p13nMode` includes `Item`.
+- Filters not applied to table: ensure `filter` association is set on Table/Chart and delegate implements `updateBindingInfo`.
+- "Go" button missing: FilterBar does not use `liveMode` by default; the Go button is standard behavior.
+- Conditions format error: always use `Condition.createCondition("EQ", ["value"])` to create conditions programmatically.

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-bar.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-bar.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.FilterBar
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.FilterBar
+API: https://ui5.sap.com/#/api/sap.ui.mdc.FilterBar
 
 ## Delegate pattern
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-field.md
@@ -1,0 +1,83 @@
+# sap.ui.mdc.FilterField
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.FilterField
+
+## Overview
+
+FilterField is a specialized field control designed to work inside an MDC FilterBar. It manages filter conditions and renders an appropriate inner control based on data type and `maxConditions`.
+
+## Key properties
+
+| Property          | Purpose                                                                     |
+| ----------------- | --------------------------------------------------------------------------- |
+| `propertyKey`     | Property key this field represents (maps to PropertyInfo `key`).            |
+| `conditions`      | Binding to the FilterBar's condition model (required).                      |
+| `dataType`        | Data type name (determines inner control).                                  |
+| `maxConditions`   | `-1` = multiple values (MultiInput), `1` = single value (Input/DatePicker). |
+| `operators`       | Array of allowed operator names (e.g., `["EQ", "BT", "Contains"]`).         |
+| `defaultOperator` | Default operator for new conditions.                                        |
+| `label`           | Display label for the filter field.                                         |
+| `valueHelp`       | Association to a ValueHelp control for value selection.                     |
+
+## Inner control selection
+
+| maxConditions | Data Type      | Inner Control              |
+| ------------- | -------------- | -------------------------- |
+| `1`           | String/Numeric | Input                      |
+| `1`           | Date           | DatePicker                 |
+| `1`           | DateTimeOffset | DateTimePicker             |
+| `-1`          | String/Numeric | MultiInput (tokens)        |
+| `-1`          | Date           | MultiInput with DatePicker |
+
+## FilterField usage within FilterBar
+
+```xml
+<mdc:FilterBar id="filterBar"
+    delegate="{name: 'my/app/delegate/FilterBarDelegate', payload: {entitySet: 'Products'}}">
+    <mdc:filterItems>
+        <mdc:FilterField propertyKey="name" label="Product Name"
+            conditions="{$filters>/conditions/name}"
+            dataType="sap.ui.model.odata.v4.type.String"
+            maxConditions="-1"/>
+        <mdc:FilterField propertyKey="price" label="Price"
+            conditions="{$filters>/conditions/price}"
+            dataType="sap.ui.model.odata.v4.type.Decimal"
+            maxConditions="1"
+            operators="EQ,BT,GE,LE"/>
+        <mdc:FilterField propertyKey="createdAt" label="Created"
+            conditions="{$filters>/conditions/createdAt}"
+            dataType="sap.ui.model.odata.v4.type.Date"
+            maxConditions="1"/>
+    </mdc:filterItems>
+</mdc:FilterBar>
+```
+
+## Conditions binding
+
+FilterField conditions use the FilterBar's internal condition model. The binding path follows the pattern:
+`{$filters>/conditions/<propertyKey>}`
+
+## Key events
+
+| Event    | Purpose                                                                     |
+| -------- | --------------------------------------------------------------------------- |
+| `change` | Fired when condition changes. Parameters: `conditions`, `valid`, `promise`. |
+
+## Operator customization
+
+Restrict available operators to limit user choices:
+
+```xml
+<mdc:FilterField propertyKey="status" operators="EQ"
+    maxConditions="1" label="Status"/>
+```
+
+Common operators: `EQ` (equals), `BT` (between), `GE` (>=), `LE` (<=), `Contains`, `StartsWith`, `EndsWith`, `Empty`, `NotEmpty`.
+
+## Troubleshooting
+
+- FilterField not showing conditions: verify `conditions` binding path matches the `propertyKey`.
+- Wrong control rendered: check `maxConditions` and `dataType` combination.
+- Operators not restricted: set `operators` property explicitly as comma-separated or array.
+- Conditions not propagating to table: FilterBar delegate must implement `updateBindingInfo`.
+- Validation error on input: `dataType` constraints don't match actual data format.

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-filter-field.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.FilterField
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.FilterField
+API: https://ui5.sap.com/#/api/sap.ui.mdc.FilterField
 
 ## Overview
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-json-delegates.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-json-delegates.md
@@ -1,0 +1,122 @@
+# MDC Controls with JSON Models
+
+## Overview
+
+MDC controls are model-agnostic — they work with any model type (JSON, OData V4, OData V2) via the delegate pattern. When using JSON models, extend the **base** delegates directly (not the OData V4 variants) and provide PropertyInfo manually.
+
+## Base delegates for JSON models
+
+| Control   | Base Delegate (JSON)           | OData V4 Delegate (do NOT use with JSON) |
+| --------- | ------------------------------ | ---------------------------------------- |
+| Table     | `sap/ui/mdc/TableDelegate`     | `sap/ui/mdc/odata/v4/TableDelegate`      |
+| FilterBar | `sap/ui/mdc/FilterBarDelegate` | `sap/ui/mdc/odata/v4/FilterBarDelegate`  |
+| ValueHelp | `sap/ui/mdc/ValueHelpDelegate` | (same base for all models)               |
+
+## Key differences from OData V4
+
+| Aspect              | OData V4                            | JSON Model                                               |
+| ------------------- | ----------------------------------- | -------------------------------------------------------- |
+| `fetchProperties`   | Can introspect OData metadata       | Must return PropertyInfo array manually                  |
+| `dataType`          | `sap.ui.model.odata.v4.type.*`      | `sap.ui.model.type.*` (String, Integer, Date, etc.)      |
+| `updateBindingInfo` | Path often derived from metadata    | Must set `bindingInfo.path` from delegate payload        |
+| `addItem`           | Can auto-generate column templates  | Must create Column + inner control template manually     |
+| Search/filter       | OData `$filter` built automatically | Implement `getFilters()` returning `sap.ui.model.Filter` |
+| TypeMap             | OData types registered by default   | Register standard types via `DefaultTypeMap`             |
+
+## TypeMap registration
+
+Register type mappings so MDC recognizes your data types for condition handling:
+
+```javascript
+sap.ui.define(
+    ["sap/ui/mdc/DefaultTypeMap", "sap/ui/mdc/enums/BaseType"],
+    function (DefaultTypeMap, BaseType) {
+        DefaultTypeMap.set("sap.ui.model.type.String", BaseType.String)
+        DefaultTypeMap.set("sap.ui.model.type.Integer", BaseType.Numeric)
+        DefaultTypeMap.set("sap.ui.model.type.Date", BaseType.Date)
+        DefaultTypeMap.freeze()
+    }
+)
+```
+
+## Minimal TableDelegate for JSON
+
+```javascript
+sap.ui.define(
+    [
+        "sap/ui/mdc/TableDelegate",
+        "sap/m/Text",
+        "sap/ui/model/Filter",
+        "sap/ui/model/FilterOperator",
+    ],
+    function (TableDelegate, Text, Filter, FilterOperator) {
+        var MyDelegate = Object.assign({}, TableDelegate)
+
+        MyDelegate.fetchProperties = function (oTable) {
+            var aProperties = [
+                {
+                    key: "name",
+                    label: "Name",
+                    dataType: "sap.ui.model.type.String",
+                },
+                {
+                    key: "price",
+                    label: "Price",
+                    dataType: "sap.ui.model.type.Integer",
+                },
+            ]
+            return Promise.resolve(aProperties)
+        }
+
+        MyDelegate.addItem = function (oTable, sPropertyKey, mPropertyBag) {
+            return TableDelegate.addItem
+                .call(this, oTable, sPropertyKey, mPropertyBag)
+                .then(function (oColumn) {
+                    oColumn.setTemplate(
+                        new Text({ text: "{" + sPropertyKey + "}" })
+                    )
+                    return oColumn
+                })
+        }
+
+        MyDelegate.updateBindingInfo = function (oTable, oBindingInfo) {
+            TableDelegate.updateBindingInfo.call(this, oTable, oBindingInfo)
+            oBindingInfo.path = oTable.getPayload().bindingPath
+        }
+
+        MyDelegate.getFilters = function (oTable) {
+            var sSearch =
+                oTable._oSearchField && oTable._oSearchField.getValue()
+            if (sSearch) {
+                return [new Filter("name", FilterOperator.Contains, sSearch)]
+            }
+            return []
+        }
+
+        return MyDelegate
+    }
+)
+```
+
+## ValueHelp with JSON
+
+Load content dynamically via fragments in `retrieveContent`:
+
+```javascript
+MyVHDelegate.retrieveContent = function (oValueHelp, oContainer) {
+    return Fragment.load({
+        name: "my.app.fragment.ValueHelpContent",
+    }).then(function (oContent) {
+        oContainer.addContent(oContent)
+    })
+}
+```
+
+Use `filterFields="$search"` on MTable content for automatic client-side filtering.
+
+## When to use JSON delegates
+
+- **Prototyping:** rapid UI development without backend service
+- **Local/static data:** configuration lists, enum values, cached data
+- **CAP development:** mock data during early development before OData service is stable
+- **Hybrid scenarios:** part of the UI driven by JSON while other parts use OData V4

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-link.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-link.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.Link
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.Link
+API: https://ui5.sap.com/#/api/sap.ui.mdc.Link
 
 ## Overview
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-link.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-link.md
@@ -1,0 +1,92 @@
+# sap.ui.mdc.Link
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.Link
+
+## Overview
+
+MDC Link provides delegate-driven navigation with three display modes: plain text, direct navigation, or a popover with multiple link targets. Used as `fieldInfo` inside an MDC Field.
+
+## LinkType enum
+
+| Type         | Behavior                                  |
+| ------------ | ----------------------------------------- |
+| `Text`       | Renders as plain text (no interaction).   |
+| `DirectLink` | Auto-navigates to single target on click. |
+| `Popup`      | Opens panel with navigation options.      |
+
+## Delegate pattern
+
+App developers implement a `LinkDelegate` with three key methods:
+
+```javascript
+sap.ui.define(["sap/ui/mdc/LinkDelegate"], function (LinkDelegate) {
+    const MyLinkDelegate = Object.assign({}, LinkDelegate)
+
+    // Determine how the link renders
+    MyLinkDelegate.fetchLinkType = function (oLink) {
+        return Promise.resolve({
+            initialType: {
+                type: 2, // LinkType.Popup
+                directLink: undefined,
+            },
+        })
+    }
+
+    // Provide navigation targets for the popover
+    MyLinkDelegate.fetchLinkItems = function (oLink) {
+        return Promise.resolve([
+            new LinkItem({
+                key: "supplierDetail",
+                text: "Supplier Details",
+                href: "#/Supplier/{SupplierID}",
+            }),
+            new LinkItem({
+                key: "purchaseOrders",
+                text: "Purchase Orders",
+                href: "#/PurchaseOrders?supplier={SupplierID}",
+            }),
+        ])
+    }
+
+    // Optional: add extra content to the popover (e.g., contact card)
+    MyLinkDelegate.fetchAdditionalContent = function (oLink) {
+        return Promise.resolve([])
+    }
+
+    return MyLinkDelegate
+})
+```
+
+## Link usage as fieldInfo
+
+```xml
+<mdc:Field id="supplierField" value="{SupplierName}"
+    dataType="sap.ui.model.odata.v4.type.String" editMode="Display">
+    <mdc:fieldInfo>
+        <mdc:Link id="supplierLink"
+            delegate="{name: 'my/app/delegate/LinkDelegate', payload: {semanticObject: 'Supplier'}}"
+            enablePersonalization="true"/>
+    </mdc:fieldInfo>
+</mdc:Field>
+```
+
+## Key properties
+
+| Property                | Purpose                                                |
+| ----------------------- | ------------------------------------------------------ |
+| `delegate`              | Delegate module path and payload (required).           |
+| `enablePersonalization` | Allow users to show/hide link items (default: `true`). |
+
+## Key associations
+
+| Association     | Purpose                                                |
+| --------------- | ------------------------------------------------------ |
+| `sourceControl` | Reference to the parent control (for binding context). |
+
+## Troubleshooting
+
+- Link always shows as text: `fetchLinkType` returns `Text` type or fails. Verify delegate returns type `2` (Popup) or `1` (DirectLink).
+- Popover empty (no links): `fetchLinkItems` returns empty array. Verify delegate returns valid LinkItem objects.
+- Direct navigation not working: `fetchLinkType` must return `directLink` property with a valid LinkItem containing `href`.
+- Personalization not available: `enablePersonalization` is `false` or only one link item exists.
+- Link delegate not loading: verify delegate module path is correct and module is accessible.

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-multi-value-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-multi-value-field.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.MultiValueField
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.MultiValueField
+API: https://ui5.sap.com/#/api/sap.ui.mdc.MultiValueField
 
 ## Overview
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-multi-value-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-multi-value-field.md
@@ -1,0 +1,99 @@
+# sap.ui.mdc.MultiValueField
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.MultiValueField
+
+## Overview
+
+MultiValueField manages a collection of values via an `items` aggregation (unlike Field which holds a single `value`). It requires a delegate to synchronize user interactions back to the items model.
+
+## Difference from Field
+
+| Aspect        | Field                    | MultiValueField                             |
+| ------------- | ------------------------ | ------------------------------------------- |
+| Value storage | Single `value` property  | `items` aggregation (MultiValueFieldItem[]) |
+| Delegate      | Optional (for ValueHelp) | Required (`updateItems` method)             |
+| Display       | Text/Input               | Tokenizer/MultiInput                        |
+| Use case      | Single value entry       | Multiple tokens/values                      |
+
+## Delegate pattern
+
+```javascript
+sap.ui.define(
+    ["sap/ui/mdc/field/MultiValueFieldDelegate"],
+    function (MultiValueFieldDelegate) {
+        const MyDelegate = Object.assign({}, MultiValueFieldDelegate)
+
+        // Called after user interaction to sync conditions back to items
+        MyDelegate.updateItems = function (oMultiValueField, aConditions) {
+            var oListBinding = oMultiValueField.getBinding("items")
+            if (oListBinding) {
+                // Remove existing items
+                var aContexts = oListBinding.getContexts()
+                for (var i = aContexts.length - 1; i >= 0; i--) {
+                    oListBinding.getModel().remove(aContexts[i].getPath())
+                }
+                // Add new items from conditions
+                aConditions.forEach(function (oCondition) {
+                    oListBinding.create({ value: oCondition.values[0] })
+                })
+            }
+        }
+
+        return MyDelegate
+    }
+)
+```
+
+## MultiValueField usage
+
+```xml
+<mdc:MultiValueField id="tagsField"
+    delegate="{name: 'my/app/delegate/MultiValueFieldDelegate'}"
+    dataType="sap.ui.model.odata.v4.type.String"
+    editMode="Editable">
+    <mdc:items>
+        <mdc:MultiValueFieldItem key="{TagID}" description="{TagName}"/>
+    </mdc:items>
+</mdc:MultiValueField>
+```
+
+With ValueHelp:
+
+```xml
+<mdc:MultiValueField id="categoriesField"
+    delegate="{name: 'my/app/delegate/MultiValueFieldDelegate'}"
+    dataType="sap.ui.model.odata.v4.type.String"
+    valueHelp="categoriesVH">
+    <mdc:items>
+        <mdc:MultiValueFieldItem key="{CategoryID}" description="{CategoryName}"/>
+    </mdc:items>
+</mdc:MultiValueField>
+```
+
+## Key properties
+
+| Property    | Purpose                                 |
+| ----------- | --------------------------------------- |
+| `delegate`  | Delegate module path (required).        |
+| `dataType`  | Data type for value formatting.         |
+| `editMode`  | `Display`, `Editable`, `ReadOnly`.      |
+| `valueHelp` | Association to ValueHelp for selection. |
+
+## Key aggregation
+
+| Aggregation | Purpose                                                                             |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `items`     | `MultiValueFieldItem[]` — bindable to model. Each item has `key` and `description`. |
+
+## Key events
+
+| Event    | Purpose                                                           |
+| -------- | ----------------------------------------------------------------- |
+| `change` | Fired when items change. Parameters: `items`, `valid`, `promise`. |
+
+## Troubleshooting
+
+- Tokens not updating after user interaction: delegate `updateItems` not implemented or not syncing back to model.
+- Items binding not working: verify list binding path resolves to a collection in the OData model.
+- Cannot add new values: `editMode` must be `"Editable"` and delegate must handle `create` on the list binding.
+- ValueHelp selection not reflected: delegate `updateItems` must process the new conditions and update the items aggregation.

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-value-help.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-value-help.md
@@ -1,6 +1,6 @@
 # sap.ui.mdc.ValueHelp
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.ValueHelp
+API: https://ui5.sap.com/#/api/sap.ui.mdc.ValueHelp
 
 ## Architecture
 

--- a/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-value-help.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/references/mdc-value-help.md
@@ -1,0 +1,114 @@
+# sap.ui.mdc.ValueHelp
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.mdc.ValueHelp
+
+## Architecture
+
+ValueHelp has two containers that app developers configure:
+
+1. **Typeahead** (`typeahead` aggregation) — inline dropdown below the field for quick filtering
+2. **Dialog** (`dialog` aggregation) — full-screen selection dialog opened on demand
+
+Each container holds **content** controls that display selectable data.
+
+## ValueHelp usage
+
+```xml
+<mdc:Field id="categoryField" value="{CategoryID}" additionalValue="{CategoryName}"
+    display="DescriptionValue" valueHelp="categoryVH"/>
+
+<mdc:ValueHelp id="categoryVH"
+    delegate="{name: 'my/app/delegate/ValueHelpDelegate', payload: {entitySet: 'Categories'}}"
+    validateInput="true">
+    <mdc:typeahead>
+        <mdcVH:Popover title="Categories">
+            <mdcVHContent:MTable keyPath="ID" descriptionPath="Name"
+                filterFields="*Name*">
+                <Table>
+                    <columns>
+                        <Column><Text text="ID"/></Column>
+                        <Column><Text text="Name"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="{ID}"/>
+                                <Text text="{Name}"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </mdcVHContent:MTable>
+        </mdcVH:Popover>
+    </mdc:typeahead>
+    <mdc:dialog>
+        <mdcVH:Dialog title="Select Category">
+            <mdcVHContent:MTable keyPath="ID" descriptionPath="Name"
+                filterFields="$search">
+                <Table>
+                    <columns>
+                        <Column><Text text="ID"/></Column>
+                        <Column><Text text="Name"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="{ID}"/>
+                                <Text text="{Name}"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </mdcVHContent:MTable>
+        </mdcVH:Dialog>
+    </mdc:dialog>
+</mdc:ValueHelp>
+```
+
+## Content types
+
+| Content      | Purpose                                                             |
+| ------------ | ------------------------------------------------------------------- |
+| `MTable`     | Uses `sap.m.Table` for selection list.                              |
+| `MDCTable`   | Uses `sap.ui.mdc.Table` for complex selection with personalization. |
+| `Bool`       | Simple true/false selection.                                        |
+| `Conditions` | Condition panel for defining ranges/operators.                      |
+
+## Delegate pattern
+
+```javascript
+sap.ui.define(["sap/ui/mdc/ValueHelpDelegate"], function (ValueHelpDelegate) {
+    const MyVHDelegate = Object.assign({}, ValueHelpDelegate)
+
+    MyVHDelegate.retrieveContent = function (oValueHelp, oContainer) {
+        // Dynamically configure content if needed
+        return Promise.resolve()
+    }
+
+    return MyVHDelegate
+})
+```
+
+## Key properties
+
+| Property        | Purpose                                         |
+| --------------- | ----------------------------------------------- |
+| `delegate`      | Delegate module path and payload.               |
+| `validateInput` | Validate user input against value help entries. |
+
+## Connecting to Field/FilterField
+
+Set the `valueHelp` association on the Field or FilterField:
+
+```xml
+<mdc:Field valueHelp="myValueHelp" .../>
+<mdc:FilterField valueHelp="myValueHelp" .../>
+```
+
+## Troubleshooting
+
+- ValueHelp not opening: verify `valueHelp` association on Field points to correct ID.
+- Typeahead not showing: check that `typeahead` aggregation with Popover and content is defined.
+- Dialog empty: verify content binding path and that data is available for the entity set.
+- Selected value not reflected in Field: ensure `keyPath` and `descriptionPath` match model property names.
+- Validation fails on valid input: check `validateInput` setting and that content data includes the entered value.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/SKILL.md
@@ -12,8 +12,6 @@ Apply these guidelines whenever generating, reviewing, or troubleshooting UI5 sm
 
 **UI5 version baseline:** SAPUI5 1.136+ LTS. All features mentioned are available from this version unless noted.
 
-This skill complements `ui5-best-practices`. General rules (module loading, data binding types, CSP, TypeScript events) apply alongside these control-specific guidelines.
-
 ## When to load each reference
 
 | Trigger                                                                | Load                                                                                                                         |

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ui5-best-practices-smart-controls
+description: |
+    UI5 smart controls best practices and authoritative development guidelines for OData V2 annotation-driven controls. Use when the user asks to "create a SmartField", "add a SmartForm", "implement SmartFilterBar", "create SmartChart", "add SmartLink navigation", "use SmartMultiInput", "smart control annotations", "OData V2 metadata-driven controls", "sap.ui.comp", "field control annotation", "value help annotations", "ValueList annotation", "smart form layout", "smart filter bar configuration", "chart annotations", "semantic object navigation", "smart link popover", "SmartField edit mode", "SmartField display mode", "SmartFilterBar liveMode", "SmartChart drill-down", "SmartMultiInput tokens", "SmartTable configuration", or is writing any UI5 freestyle application using OData V2 annotation-driven controls from sap.ui.comp. Covers: control selection, mandatory rules, common error patterns, annotation guidance, and per-control API reference for SmartField, SmartForm, SmartFilterBar, SmartChart, SmartLink, and SmartMultiInput.
+
+    Keywords: sap.ui.comp, SmartField, SmartForm, SmartFilterBar, SmartChart, SmartLink, SmartMultiInput, SmartTable, FilterBar, sap.ui.comp.filterbar, ValueHelpDialog, sap.ui.comp.valuehelpdialog, FilterGroupItem, token selection, ranges, conditions tab, OData V2, annotations, UI.LineItem, UI.Chart, ValueList, FieldControl, SemanticObject, entitySet, ControlConfiguration, GroupConfiguration, textArrangement, value help, FilterProvider, initialise event, beforeRebindChart, navigationTargetsObtained
+---
+
+# UI5 Smart Controls Best Practices
+
+Apply these guidelines whenever generating, reviewing, or troubleshooting UI5 smart control code in freestyle applications using OData V2 services.
+
+**UI5 version baseline:** SAPUI5 1.136+ LTS. All features mentioned are available from this version unless noted.
+
+This skill complements `ui5-best-practices`. General rules (module loading, data binding types, CSP, TypeScript events) apply alongside these control-specific guidelines.
+
+## When to load each reference
+
+| Trigger                                                                | Load                                                                                                                         |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Working on or planning a `sap.ui.comp.smartfield.SmartField`           | [`references/smart-field.md`](references/smart-field.md)                                                                     |
+| Working on or planning a `sap.ui.comp.smartform.SmartForm`             | [`references/smart-form.md`](references/smart-form.md)                                                                       |
+| Working on or planning a `sap.ui.comp.smartfilterbar.SmartFilterBar`   | [`references/smart-filter-bar.md`](references/smart-filter-bar.md)                                                           |
+| Working on or planning a `sap.ui.comp.smartchart.SmartChart`           | [`references/smart-chart.md`](references/smart-chart.md)                                                                     |
+| Working on or planning a `sap.ui.comp.navpopover.SmartLink`            | [`references/smart-link.md`](references/smart-link.md)                                                                       |
+| Working on or planning a `sap.ui.comp.smartmultiinput.SmartMultiInput` | [`references/smart-multi-input.md`](references/smart-multi-input.md)                                                         |
+| Working on or planning a `sap.ui.comp.filterbar.FilterBar`             | [`references/filter-bar.md`](references/filter-bar.md)                                                                       |
+| Working on or planning a `sap.ui.comp.valuehelpdialog.ValueHelpDialog` | [`references/value-help-dialog.md`](references/value-help-dialog.md)                                                         |
+| Working on or planning a `sap.ui.comp.smarttable.SmartTable`           | See `ui5-best-practices-tables` skill, [`references/smart-table.md`](../ui5-best-practices-tables/references/smart-table.md) |
+
+Load before producing any output. Do not work from memory.
+
+---
+
+## Core Rules
+
+### Mandatory
+
+- Always specify `entitySet` on Smart controls or ensure the control inherits a binding context that resolves the entity type.
+- Use `ControlConfiguration` in XML for SmartFilterBar field overrides (control type, filter type, index). Only `visible`, `label`, and `visibleInAdvancedArea` can be changed at runtime.
+- Use the correct hierarchy: `SmartForm > Group > GroupElement > SmartField`. Never place SmartFields directly in a SmartForm.
+- Wait for the `initialise` event before programmatically accessing inner controls (e.g., `getInnerControl()`, `getChart()`).
+- Use `sap.ui.model.odata.type.*` types in bindings alongside OData V2 models. Never use `sap.ui.model.type.*` with OData V2.
+- Set `ariaLabelledBy` on SmartFilterBar and SmartChart referencing a visible title for accessibility.
+- Use `check()` on SmartForm for client-side mandatory field validation before submitting data.
+- Use `get_api_reference` MCP tool to verify control APIs. Use `run_ui5_linter` to validate code.
+
+### Prohibitions
+
+- Do not use Smart controls with OData V4 services. Use MDC controls (`sap.ui.mdc`) instead.
+- Do not set custom formatters on SmartField `value` property. SmartField manages its own rendering based on metadata. Use annotations to influence behavior.
+- Do not use composite binding syntax (`parts: [...]`) on SmartField. It manages its own composite bindings for unit/currency fields.
+- Do not call `getChart()` synchronously during initialization. Use the `initialise` event or `getChartAsync()`.
+- Do not directly modify inner controls of SmartChart or SmartTable (e.g., the inner `sap.chart.Chart`). Use the smart control's public API.
+- Do not hardcode field labels. Use `sap:label` or `@Common.Label` annotations in OData metadata.
+- Do not use inline styles or scripts in HTML (CSP compliance).
+- Do not use global access (`sap.ui.comp.smartfield.SmartField`). Use `sap.ui.define` or ES6 imports.
+
+---
+
+## Selection Matrix
+
+| Control           | Use when                                                                           | Do not use when                                                                   |
+| ----------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `SmartField`      | OData V2, single property display/edit, auto-rendering by Edm type and annotations | OData V4, JSON models, custom rendering required, composite/multi-property fields |
+| `SmartForm`       | OData V2, entity editing with multiple SmartFields, auto-labels from annotations   | OData V4, complex custom layouts, non-OData data                                  |
+| `SmartFilterBar`  | OData V2, annotation-driven filter UI, integration with SmartTable/SmartChart      | OData V4 (use MDC FilterBar), JSON-only, purely custom filter logic               |
+| `SmartChart`      | OData V2, annotation-driven chart visualization, drill-down, variant management    | OData V4 (use MDC Chart), non-analytical data, custom chart JS                    |
+| `SmartLink`       | OData V2, semantic object navigation, cross-app navigation via FLP                 | OData V4 (use MDC Link), simple static links, no FLP available                    |
+| `SmartMultiInput` | OData V2, multi-value entry with tokens, value help with ranges                    | OData V4, simple single-value input, JSON-only                                    |
+| `FilterBar`       | Manual filter UI without OData annotations, inside ValueHelpDialog, custom filters | OData V2 with annotations (use SmartFilterBar), OData V4 (use MDC FilterBar)      |
+| `ValueHelpDialog` | Complex value selection with table + conditions tabs, token-based multi-select     | Simple dropdowns, single-value selection, OData V4 (use MDC ValueHelp)            |
+
+---
+
+## Common Errors
+
+| Symptom                                        | Cause                                                       | Fix                                                                 |
+| ---------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------- |
+| SmartField renders as plain text in edit mode  | Missing binding context or wrong `entitySet`                | Verify `value="{PropertyName}"` and entity context resolution.      |
+| SmartField shows Input instead of DatePicker   | Missing `sap:display-format="Date"` on property             | Add annotation or use `controlType` in ControlConfiguration.        |
+| SmartForm labels missing                       | `sap:label` annotation not set in OData metadata            | Add `sap:label` to property or set `label` on GroupElement.         |
+| SmartFilterBar type-ahead not working          | Missing `ValueList` annotation with correct target path     | Verify target: `{Namespace}.{EntityName}/{FieldName}`.              |
+| SmartFilterBar default values ignored          | Setting ControlConfiguration dynamically after `initialise` | Set values statically in XML or use `setFilterData()` API.          |
+| SmartChart height is 0 / not visible           | Container does not provide explicit height                  | Set height on parent container (e.g., `height="50vh"`).             |
+| SmartChart missing dimensions/measures         | Wrong or missing `UI.Chart` annotation                      | Verify `MeasureAttributes` and `DimensionAttributes` in annotation. |
+| SmartLink popover shows "No content available" | No navigation targets for semantic object in FLP            | Verify FLP configuration and user authorizations.                   |
+| SmartLink rendered as text (not clickable)     | No `SemanticObject` annotation on property                  | Add `@Common.SemanticObject` annotation to OData property.          |
+| SmartMultiInput tokens not persisting          | Missing ValueList or incorrect binding                      | Verify ValueList annotation and navigation property binding.        |
+
+---
+
+## Performance & Accessibility
+
+### Anti-patterns to avoid
+
+- Requesting all value lists eagerly (use lazy loading; value lists load on-demand by default).
+- Using `liveMode="true"` on SmartFilterBar with expensive backend queries (causes rapid re-fetching).
+- Deep nesting of SmartForm groups (keep hierarchy flat: Form > Group > GroupElement).
+- Bypassing SmartChart API to modify inner chart directly (breaks personalization and variant management).
+- Not setting `ignoredChartTypes` when certain chart types are irrelevant (unnecessary UI options).
+
+### Accessibility checklist
+
+- Set `ariaLabelledBy` on SmartFilterBar referencing a visible title.
+- Set `ariaLabelledBy` on SmartChart referencing a visible title.
+- SmartForm automatically propagates labels to SmartFields via annotations.
+- Verify keyboard navigation works for SmartFilterBar "Adapt Filters" dialog.
+- Test SmartLink popover with screen reader (navigation targets must be announced).

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/filter-bar.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/filter-bar.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.filterbar.FilterBar
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.filterbar.FilterBar
+API: https://ui5.sap.com/#/api/sap.ui.comp.filterbar.FilterBar
 
 ## Overview
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/filter-bar.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/filter-bar.md
@@ -1,0 +1,78 @@
+# sap.ui.comp.filterbar.FilterBar
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.filterbar.FilterBar
+
+## Overview
+
+FilterBar is the lower-level filter control requiring manual `FilterGroupItem` configuration. Use it when OData annotations are not available (e.g., inside `ValueHelpDialog`) or when you need full programmatic control over filter fields. For annotation-driven filtering with OData V2, use `SmartFilterBar` instead.
+
+## Key properties
+
+| Property                  | Purpose                                                             |
+| ------------------------- | ------------------------------------------------------------------- |
+| `persistencyKey`          | Key for variant management (enables Save as Tile / Manage Variants) |
+| `filterBarExpanded`       | Whether the filter bar is expanded initially (`true` by default)    |
+| `advancedMode`            | Hides Go button; used inside ValueHelpDialog (`false` by default)   |
+| `showGoOnFB`              | Show/hide Go button explicitly                                      |
+| `showFilterConfiguration` | Show/hide "Adapt Filters" button                                    |
+| `header`                  | Title text displayed above the filter bar                           |
+
+## Key API methods
+
+| Method               | Purpose                                                      |
+| -------------------- | ------------------------------------------------------------ |
+| `addFilterGroupItem` | Add a FilterGroupItem with control, name, and group          |
+| `getFilters()`       | Returns array of `sap.ui.model.Filter` for all filled fields |
+| `search()`           | Triggers the `search` event programmatically                 |
+| `getUiState()`       | Returns current filter state as JSON (for persistence)       |
+| `setUiState()`       | Restores filter state from JSON                              |
+| `setFilterData()`    | Sets filter values programmatically                          |
+
+## FilterBar usage
+
+```xml
+<comp:filterbar.FilterBar id="myFilterBar"
+    header="Product Filters" showGoOnFB="true"
+    showFilterConfiguration="true" filterBarExpanded="true"
+    search=".onSearch">
+    <comp:filterGroupItems>
+        <comp:filterbar.FilterGroupItem name="name" label="Name"
+            groupName="basic" visibleInFilterBar="true">
+            <comp:control>
+                <Input value="{filterModel>/name}"/>
+            </comp:control>
+        </comp:filterbar.FilterGroupItem>
+        <comp:filterbar.FilterGroupItem name="category" label="Category"
+            groupName="basic" visibleInFilterBar="true">
+            <comp:control>
+                <Select selectedKey="{filterModel>/category}"
+                    items="{/Categories}">
+                    <core:Item key="{ID}" text="{Name}"/>
+                </Select>
+            </comp:control>
+        </comp:filterbar.FilterGroupItem>
+        <comp:filterbar.FilterGroupItem name="createdAt" label="Created Date"
+            groupName="basic" visibleInFilterBar="true">
+            <comp:control>
+                <DatePicker value="{filterModel>/createdAt}"/>
+            </comp:control>
+        </comp:filterbar.FilterGroupItem>
+    </comp:filterGroupItems>
+</comp:filterbar.FilterBar>
+```
+
+## Key events
+
+| Event    | Purpose                                          |
+| -------- | ------------------------------------------------ |
+| `search` | Fired when Go is pressed or `search()` is called |
+| `reset`  | Fired when user resets all filters               |
+| `clear`  | Fired when user clears all filter values         |
+
+## Troubleshooting
+
+- Go button not visible: `showGoOnFB` is `false` or `advancedMode` is `true`. Set `showGoOnFB="true"` and `advancedMode="false"`.
+- `getFilters()` returns empty array: filter controls are not bound or no values entered. Verify control bindings.
+- Variant management not working: `persistencyKey` not set. Add a unique `persistencyKey` string.
+- Filters not shown initially: `visibleInFilterBar` is `false` on FilterGroupItems. Set to `true` for default-visible fields.
+- FilterGroupItem control is null: `control` aggregation not set. Each FilterGroupItem must contain exactly one control.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-chart.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-chart.md
@@ -1,0 +1,93 @@
+# sap.ui.comp.smartchart.SmartChart
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartchart.SmartChart
+
+## Key annotations
+
+| Annotation                      | Purpose                                                             |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `@UI.Chart`                     | Defines chart type, dimensions, measures, and roles.                |
+| `@UI.Chart.ChartType`           | Default chart type (`Column`, `Bar`, `Line`, `Pie`, `Donut`, etc.). |
+| `@UI.Chart.MeasureAttributes`   | Maps measures to roles (`Axis1`, `Axis2`, `Axis3`).                 |
+| `@UI.Chart.DimensionAttributes` | Maps dimensions to roles (`Category`, `Series`).                    |
+| `@Analytics.Dimension`          | Marks property as dimension.                                        |
+| `@Analytics.Measure`            | Marks property as measure.                                          |
+
+## Annotation pattern
+
+```xml
+<Annotations Target="MyService.SalesData">
+    <Annotation Term="UI.Chart">
+        <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column"/>
+            <PropertyValue Property="Dimensions">
+                <Collection><PropertyPath>Category</PropertyPath></Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+                <Collection><PropertyPath>Revenue</PropertyPath></Collection>
+            </PropertyValue>
+            <PropertyValue Property="DimensionAttributes">
+                <Collection>
+                    <Record Type="UI.ChartDimensionAttributeType">
+                        <PropertyValue Property="Dimension" PropertyPath="Category"/>
+                        <PropertyValue Property="Role" EnumMember="UI.ChartDimensionRoleType/Category"/>
+                    </Record>
+                </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+                <Collection>
+                    <Record Type="UI.ChartMeasureAttributeType">
+                        <PropertyValue Property="Measure" PropertyPath="Revenue"/>
+                        <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1"/>
+                    </Record>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+</Annotations>
+```
+
+## SmartChart configuration
+
+```xml
+<smartChart:SmartChart id="smartChart" entitySet="SalesData"
+    chartType="Column" header="Sales Overview"
+    showDrillBreadcrumbs="true" showChartTooltip="true"
+    useVariantManagement="true" useChartPersonalisation="true"
+    smartFilterId="smartFilterBar" height="400px"/>
+```
+
+## Key properties
+
+| Property               | Purpose                                                  |
+| ---------------------- | -------------------------------------------------------- |
+| `entitySet`            | OData entity set (required).                             |
+| `chartType`            | Default chart type.                                      |
+| `smartFilterId`        | ID of connected SmartFilterBar.                          |
+| `showDrillBreadcrumbs` | Shows drill-down navigation trail.                       |
+| `ignoredChartTypes`    | Comma-separated list of chart types to hide.             |
+| `height`               | Explicit height (required — chart collapses without it). |
+
+## Key events
+
+| Event               | Purpose                                            |
+| ------------------- | -------------------------------------------------- |
+| `initialise`        | Chart fully ready. Safe to call `getChartAsync()`. |
+| `beforeRebindChart` | Modify binding parameters before data fetch.       |
+
+## beforeRebindChart usage
+
+```javascript
+onBeforeRebindChart: function(oEvent) {
+    var oBindingParams = oEvent.getParameter("bindingParams");
+    oBindingParams.filters.push(new Filter("Status", "EQ", "Active"));
+}
+```
+
+## Troubleshooting
+
+- Chart not visible / height 0: set explicit `height` on SmartChart or container.
+- Missing dimensions/measures: verify `UI.Chart` annotation with correct property paths.
+- Chart type unavailable: data combination doesn't support it; check `getAvailableChartTypes()`.
+- No data after filter: verify `smartFilterId` connection and `beforeRebindChart` filter logic.
+- Cannot modify inner chart: use SmartChart public API; direct inner chart access is unsupported.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-chart.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-chart.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.smartchart.SmartChart
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartchart.SmartChart
+API: https://ui5.sap.com/#/api/sap.ui.comp.smartchart.SmartChart
 
 ## Key annotations
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-field.md
@@ -1,0 +1,67 @@
+# sap.ui.comp.smartfield.SmartField
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartfield.SmartField
+
+## Key annotations
+
+| Annotation                       | Purpose                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `@Common.ValueList`              | Enables value help dialog and type-ahead suggestions.                           |
+| `sap:value-list="fixed-values"`  | Renders ComboBox instead of Input with value help.                              |
+| `@Common.FieldControl`           | Controls field state: 7=Mandatory, 3=Optional, 1=ReadOnly, 0=Hidden.            |
+| `@Common.TextArrangement`        | Controls ID/description display: `TextFirst`, `TextLast`, `TextOnly`, `IDOnly`. |
+| `@Common.SemanticObject`         | Renders as SmartLink for cross-app navigation.                                  |
+| `sap:display-format="Date"`      | Forces DatePicker for `Edm.DateTime` (instead of DateTimePicker).               |
+| `sap:display-format="UpperCase"` | Enforces uppercase input for `Edm.String`.                                      |
+| `@UI.MultiLineText`              | Renders TextArea in edit mode.                                                  |
+
+## Control selection by Edm type
+
+**Edit mode:**
+
+| Edm Type       | Annotations            | Inner Control  |
+| -------------- | ---------------------- | -------------- |
+| Boolean        | —                      | CheckBox       |
+| String         | ValueList fixed-values | ComboBox       |
+| String         | MultiLineText          | TextArea       |
+| String         | —                      | Input          |
+| DateTime       | display-format="Date"  | DatePicker     |
+| DateTimeOffset | —                      | DateTimePicker |
+| Time           | —                      | TimePicker     |
+| Numeric types  | —                      | Input          |
+
+**Display mode:** All types render as `sap.m.Text` unless `SemanticObject` is set (renders SmartLink) or `sap:semantics="url"` (renders Link).
+
+## SmartField usage
+
+```xml
+<smartField:SmartField id="nameField" value="{Name}"
+    entitySet="Products" editable="true"/>
+```
+
+Within a SmartForm (recommended):
+
+```xml
+<smartForm:GroupElement label="Product Name">
+    <smartField:SmartField value="{Name}"/>
+</smartForm:GroupElement>
+```
+
+## Key properties
+
+| Property               | Purpose                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `value`                | Binding to OData property.                                              |
+| `editable`             | Toggle edit/display mode.                                               |
+| `entitySet`            | Explicit entity set (when binding context is unavailable).              |
+| `textInEditModeSource` | Text arrangement source: `NavigationProperty`, `ValueList`.             |
+| `controlType`          | Override inner control: `"dropDownList"`, `"datePicker"`, `"checkBox"`. |
+| `mandatory`            | Client-side mandatory flag.                                             |
+
+## Troubleshooting
+
+- SmartField renders wrong control: verify Edm type and annotations in `$metadata`.
+- Value help not working: check `ValueList` annotation target format `{Namespace}.{Entity}/{Property}`.
+- FieldControl has no effect: annotation can only _restrict_ (make more restrictive than XML); it never _expands_ permissions.
+- Custom formatter on `value` is ignored: SmartField manages its own formatting; use annotations instead.
+- Text arrangement shows ID only: verify `TextArrangement` annotation and that the text navigation property exists.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-field.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-field.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.smartfield.SmartField
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartfield.SmartField
+API: https://ui5.sap.com/#/api/sap.ui.comp.smartfield.SmartField
 
 ## Key annotations
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-filter-bar.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-filter-bar.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.smartfilterbar.SmartFilterBar
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartfilterbar.SmartFilterBar
+API: https://ui5.sap.com/#/api/sap.ui.comp.smartfilterbar.SmartFilterBar
 
 ## Key properties
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-filter-bar.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-filter-bar.md
@@ -1,0 +1,84 @@
+# sap.ui.comp.smartfilterbar.SmartFilterBar
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartfilterbar.SmartFilterBar
+
+## Key properties
+
+| Property                          | Purpose                                                          |
+| --------------------------------- | ---------------------------------------------------------------- |
+| `entitySet`                       | OData entity set for automatic filter field generation.          |
+| `enableBasicSearch`               | Adds free-text search field.                                     |
+| `liveMode`                        | Auto-triggers search on filter change (no "Go" button).          |
+| `useDateRangeType`                | Renders date fields as DynamicDateRange with semantic operators. |
+| `useProvidedNavigationProperties` | Only expose filter fields from specified navigation properties.  |
+| `navigationProperties`            | Comma-separated navigation property names to include.            |
+
+## ControlConfiguration pattern
+
+```xml
+<smartFilterBar:SmartFilterBar id="smartFilterBar" entitySet="Products"
+    enableBasicSearch="true" useTablePersonalisation="true">
+    <smartFilterBar:controlConfiguration>
+        <smartFilterBar:ControlConfiguration key="Category"
+            controlType="dropDownList" filterType="multiple"
+            index="0" visibleInAdvancedArea="true"
+            hasValueHelpDialog="true" hasTypeAhead="true"/>
+        <smartFilterBar:ControlConfiguration key="CreatedAt"
+            controlType="date" filterType="interval" index="1">
+            <smartFilterBar:defaultFilterValues>
+                <smartFilterBar:SelectOption low="2024-01-01" high="2024-12-31" operator="BT"/>
+            </smartFilterBar:defaultFilterValues>
+        </smartFilterBar:ControlConfiguration>
+    </smartFilterBar:controlConfiguration>
+</smartFilterBar:SmartFilterBar>
+```
+
+Only `visible`, `label`, and `visibleInAdvancedArea` can be changed dynamically after `initialise`. All other ControlConfiguration properties are static.
+
+## Connecting to SmartTable/SmartChart
+
+```xml
+<smartFilterBar:SmartFilterBar id="smartFilterBar" entitySet="Products"/>
+<smartTable:SmartTable smartFilterId="smartFilterBar" entitySet="Products"
+    tableType="ResponsiveTable" enableAutoBinding="true"/>
+```
+
+## Public API methods
+
+| Method                 | Returns                 | Purpose                                       |
+| ---------------------- | ----------------------- | --------------------------------------------- |
+| `getFilters()`         | `sap.ui.model.Filter[]` | Filter objects for data binding.              |
+| `getFilterData()`      | `Object`                | Raw filter field values (not Filter objects). |
+| `setFilterData(oData)` | void                    | Set filter values programmatically.           |
+| `search()`             | void                    | Trigger search programmatically.              |
+| `clear()`              | void                    | Clear all filter values.                      |
+
+## Setting filter data dynamically
+
+```javascript
+// In initialise event handler
+onFilterBarInitialise: function() {
+    var oFilterBar = this.byId("smartFilterBar");
+    oFilterBar.setFilterData({
+        Category: { items: [{key: "Electronics", text: "Electronics"}] },
+        CreatedAt: { low: new Date("2024-01-01"), high: new Date("2024-12-31") },
+        Status: "Active"
+    });
+}
+```
+
+## Key events
+
+| Event          | Purpose                                                   |
+| -------------- | --------------------------------------------------------- |
+| `initialise`   | Fired once after metadata loaded. Safe to access filters. |
+| `search`       | Fired when "Go" pressed or liveMode triggers.             |
+| `filterChange` | Fired when any filter value changes.                      |
+
+## Troubleshooting
+
+- No filter fields generated: `entitySet` not set or metadata not loaded.
+- Type-ahead not working: missing `ValueList` annotation; target format: `{Namespace}.{Entity}/{Field}`.
+- Default values ignored at runtime: only `visible`/`label`/`visibleInAdvancedArea` are dynamic; use `setFilterData()` for values.
+- Wrong control type: verify Edm type and `sap:display-format` annotation match the desired control.
+- Custom field values lost on variant load: implement `beforeVariantFetch`/`afterVariantLoad` with `_CUSTOM` data.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-form.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-form.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.smartform.SmartForm
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartform.SmartForm
+API: https://ui5.sap.com/#/api/sap.ui.comp.smartform.SmartForm
 
 ## Key properties
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-form.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-form.md
@@ -1,0 +1,77 @@
+# sap.ui.comp.smartform.SmartForm
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartform.SmartForm
+
+## Key properties
+
+| Property         | Purpose                                                    |
+| ---------------- | ---------------------------------------------------------- |
+| `editable`       | Propagates edit/display mode to all nested SmartFields.    |
+| `editTogglable`  | Shows edit/display toggle button in form toolbar.          |
+| `title`          | Form title (rendered in toolbar).                          |
+| `expandable`     | Renders as collapsible panel.                              |
+| `flexEnabled`    | Enables key-user adaptation (add/remove/rearrange fields). |
+| `entityType`     | OData entity type for metadata annotation reading.         |
+| `validationMode` | `"Standard"` (sync) or `"Async"` validation.               |
+
+## Required hierarchy
+
+```xml
+<smartForm:SmartForm id="myForm" editable="true" title="Product Details"
+    editTogglable="true" entityType="Product">
+    <smartForm:layout>
+        <smartForm:ColumnLayout columnsM="2" columnsL="3" columnsXL="4"/>
+    </smartForm:layout>
+    <smartForm:Group label="General">
+        <smartForm:GroupElement label="Name">
+            <smartField:SmartField value="{Name}"/>
+        </smartForm:GroupElement>
+        <smartForm:GroupElement label="Price">
+            <smartField:SmartField value="{Price}"/>
+        </smartForm:GroupElement>
+    </smartForm:Group>
+    <smartForm:Group label="Details">
+        <smartForm:GroupElement label="Description">
+            <smartField:SmartField value="{Description}"/>
+        </smartForm:GroupElement>
+    </smartForm:Group>
+</smartForm:SmartForm>
+```
+
+## Layout options
+
+| Layout                 | Use when                                       |
+| ---------------------- | ---------------------------------------------- |
+| `ColumnLayout`         | Recommended default. Responsive columns.       |
+| `ResponsiveGridLayout` | Need fine-grained grid control (span, offset). |
+
+Always provide a layout. `ColumnLayout` with `columnsM="2" columnsL="3" columnsXL="4"` is the recommended default (consistent with `ui5-best-practices` form rules).
+
+## Validation
+
+Call `check()` before save to validate mandatory fields:
+
+```javascript
+// In controller (sap.ui.define pattern)
+onSave: function() {
+    var oSmartForm = this.byId("myForm");
+    var aErrors = oSmartForm.check();
+    if (aErrors.length === 0) {
+        // proceed with save
+    }
+}
+```
+
+## Key events
+
+| Event         | Purpose                                                 |
+| ------------- | ------------------------------------------------------- |
+| `editToggled` | Fired when edit/display mode changes via toggle button. |
+
+## Troubleshooting
+
+- Labels missing: `sap:label` annotation not on OData property. Set `label` on GroupElement as fallback.
+- Validation skipped: forgot to call `check()` before save.
+- Layout broken: placed non-SmartField controls (Panels, VBoxes) inside GroupElement.
+- Flexibility not working: `entityType` not set (flexibility needs metadata context).
+- Nested SmartForms: not supported; use one SmartForm with multiple Groups.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-link.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-link.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.navpopover.SmartLink
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.navpopover.SmartLink
+API: https://ui5.sap.com/#/api/sap.ui.comp.navpopover.SmartLink
 
 ## Key annotations
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-link.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-link.md
@@ -1,0 +1,80 @@
+# sap.ui.comp.navpopover.SmartLink
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.navpopover.SmartLink
+
+## Key annotations
+
+| Annotation                                 | Purpose                                              |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `@Common.SemanticObject`                   | Identifies the navigation target semantic object.    |
+| `@Common.SemanticObjectMapping`            | Maps local properties to semantic object parameters. |
+| `@Common.SemanticObjectUnavailableActions` | Hides specific actions from the popover.             |
+
+## Operation modes
+
+| Mode             | Behavior                                                              |
+| ---------------- | --------------------------------------------------------------------- |
+| Single target    | Direct navigation (no popover) if only 1 target and no extra content. |
+| Multiple targets | Opens popover showing all navigation options.                         |
+| No targets       | Renders as plain text (not clickable).                                |
+
+## Standalone usage
+
+```xml
+<smartLink:SmartLink id="supplierLink" text="{SupplierName}"
+    semanticObject="Supplier"
+    additionalSemanticObjects="Company,Partner"
+    mapFieldToSemanticObject="true"
+    fieldName="SupplierID"
+    semanticObjectController="semanticObjectController"/>
+```
+
+## Usage within SmartTable column
+
+SmartLink renders automatically when a SmartTable column property has the `@Common.SemanticObject` annotation. No additional XML configuration needed — the SmartTable/SmartField uses SmartLink as the inner control.
+
+## Customizing navigation targets
+
+Use `navigationTargetsObtained` event to add custom links or extra content:
+
+```javascript
+// In controller (sap.ui.define pattern)
+onNavigationTargetsObtained: function(oEvent) {
+    var oParams = oEvent.getParameters();
+    var oMainNavigation = oParams.mainNavigation;
+
+    // Add extra content (e.g., a form with details)
+    oParams.show(oMainNavigation, null, undefined, new SimpleForm({
+        content: [
+            new Label({text: "Contact"}),
+            new Text({text: oParams.semanticAttributes.ContactName})
+        ]
+    }));
+}
+```
+
+## Key properties
+
+| Property                    | Purpose                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| `semanticObject`            | Navigation target name (overrides annotation).              |
+| `additionalSemanticObjects` | Comma-separated additional semantic objects.                |
+| `mapFieldToSemanticObject`  | Auto-map field value as semantic object parameter.          |
+| `fieldName`                 | OData property name for parameter mapping.                  |
+| `contactAnnotationPath`     | Path to `Communication.Contact` for contact card rendering. |
+
+## Key events
+
+| Event                       | Purpose                                    |
+| --------------------------- | ------------------------------------------ |
+| `navigationTargetsObtained` | Customize popover content before display.  |
+| `beforePopoverOpens`        | Final modification before popover renders. |
+| `innerNavigate`             | Fired when user clicks a navigation link.  |
+
+## Troubleshooting
+
+- Popover shows "No content available": no navigation targets found for semantic object in FLP. Verify FLP configuration and user authorizations.
+- Rendered as plain text (not link): `@Common.SemanticObject` annotation missing on property in OData metadata.
+- Wrong parameters passed to target: verify `@Common.SemanticObjectMapping` or use `mapFieldToSemanticObject`.
+- Extra content not showing: ensure `oParams.show()` is called with the extra content parameter.
+- Popover opens but links are wrong: check `SemanticObjectUnavailableActions` annotation to filter unwanted actions.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-multi-input.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-multi-input.md
@@ -1,0 +1,59 @@
+# sap.ui.comp.smartmultiinput.SmartMultiInput
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartmultiinput.SmartMultiInput
+
+## Overview
+
+SmartMultiInput extends SmartField for multi-value scenarios. It renders MultiInput or MultiComboBox based on annotations, supporting token-based entry with value help and range conditions.
+
+## Key properties
+
+| Property               | Purpose                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `supportMultiSelect`   | Enables multiple selection in value help dialog (default: `true`).           |
+| `supportRanges`        | Enables range conditions in value help (only works without binding context). |
+| `singleTokenMode`      | Allows only one token (only in no-binding-context scenario).                 |
+| `enableODataSelect`    | Enables `$select` optimization for value help requests.                      |
+| `requestAtLeastFields` | Comma-separated fields to always include in `$select`.                       |
+
+## Required annotations
+
+A `@Common.ValueList` annotation on the bound property is mandatory for type-ahead and value help to work. Same annotation format as SmartField.
+
+## Usage with navigation property binding
+
+```xml
+<smartMultiInput:SmartMultiInput id="categories"
+    value="{Categories/CategoryId}"
+    supportMultiSelect="true"/>
+```
+
+## Usage without binding context
+
+```xml
+<smartMultiInput:SmartMultiInput id="categories"
+    entitySet="Categories" value="{CategoryId}"
+    supportMultiSelect="true" supportRanges="true"/>
+```
+
+## Key events
+
+| Event             | Purpose                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| `tokenUpdate`     | Fired when tokens are added or removed. Parameters: `type`, `addedTokens`, `removedTokens`. |
+| `selectionChange` | Fired for selection changes on fixed-value controls (MultiComboBox).                        |
+
+## Public API methods
+
+| Method                 | Purpose                             |
+| ---------------------- | ----------------------------------- |
+| `getTokens()`          | Retrieve currently selected tokens. |
+| `setFilterData(oData)` | Set values programmatically.        |
+
+## Troubleshooting
+
+- Type-ahead not working: missing `ValueList` annotation. Verify target: `{Namespace}.{Entity}/{Property}`.
+- `supportRanges` has no effect: only works without binding context (use `entitySet` property instead of context binding).
+- Tokens not persisting: verify navigation property binding is correct and model supports create/delete operations.
+- `singleTokenMode` ignored: only works in no-binding-context scenario (when `entitySet` is specified directly).
+- Cannot set tokens programmatically: use `setFilterData()` API, not direct `setValue()` or `setTokens()`.

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-multi-input.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/smart-multi-input.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.smartmultiinput.SmartMultiInput
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.smartmultiinput.SmartMultiInput
+API: https://ui5.sap.com/#/api/sap.ui.comp.smartmultiinput.SmartMultiInput
 
 ## Overview
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/value-help-dialog.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/value-help-dialog.md
@@ -1,6 +1,6 @@
 # sap.ui.comp.valuehelpdialog.ValueHelpDialog
 
-API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.valuehelpdialog.ValueHelpDialog
+API: https://ui5.sap.com/#/api/sap.ui.comp.valuehelpdialog.ValueHelpDialog
 
 ## Overview
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/references/value-help-dialog.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/references/value-help-dialog.md
@@ -1,0 +1,135 @@
+# sap.ui.comp.valuehelpdialog.ValueHelpDialog
+
+API: https://ui5.sap.com/1.136.0/api/sap.ui.comp.valuehelpdialog.ValueHelpDialog
+
+## Overview
+
+ValueHelpDialog is a multi-modal selection dialog with two tabs: **Items** (table-based selection) and **Conditions** (range/operator-based entry). It manages selection via tokens and integrates with `FilterBar` for search within the dialog. Used when SmartField's built-in value help is insufficient or when standalone value selection is needed.
+
+## Key properties
+
+| Property             | Purpose                                           |
+| -------------------- | ------------------------------------------------- |
+| `key`                | Property name for the key field in the data       |
+| `descriptionKey`     | Property name for the description field           |
+| `supportMultiselect` | Enable multiple row selection (`true` by default) |
+| `supportRanges`      | Show Conditions tab for range/operator entry      |
+| `supportRangesOnly`  | Show only the Conditions tab (no Items tab)       |
+| `stretch`            | Stretch dialog to full viewport on phones         |
+| `title`              | Dialog title text                                 |
+| `filterMode`         | Set to `true` when used with FilterBar for search |
+
+## Key API methods
+
+| Method                | Purpose                                                 |
+| --------------------- | ------------------------------------------------------- |
+| `setTable()`          | Set the items table (sap.m.Table or sap.ui.table.Table) |
+| `setFilterBar()`      | Set the FilterBar for in-dialog filtering               |
+| `setTokens()`         | Set pre-selected tokens                                 |
+| `getTokens()`         | Get currently selected tokens                           |
+| `update()`            | Refresh the dialog after data changes                   |
+| `setRangeKeyFields()` | Define fields available in the Conditions tab           |
+
+## ValueHelpDialog usage
+
+```javascript
+sap.ui.define(
+    [
+        "sap/ui/comp/valuehelpdialog/ValueHelpDialog",
+        "sap/ui/comp/filterbar/FilterBar",
+        "sap/m/Table",
+        "sap/m/Column",
+        "sap/m/ColumnListItem",
+        "sap/m/Text",
+        "sap/m/Input",
+    ],
+    function (
+        ValueHelpDialog,
+        FilterBar,
+        Table,
+        Column,
+        ColumnListItem,
+        Text,
+        Input
+    ) {
+        var oVHD = new ValueHelpDialog({
+            title: "Select Product",
+            key: "ProductID",
+            descriptionKey: "ProductName",
+            supportMultiselect: true,
+            supportRanges: true,
+            ok: function (oEvent) {
+                var aTokens = oEvent.getParameter("tokens")
+                // Process selected tokens
+                oVHD.close()
+            },
+            cancel: function () {
+                oVHD.close()
+            },
+        })
+
+        // Create and set the items table
+        var oTable = new Table({
+            columns: [
+                new Column({ header: new Text({ text: "ID" }) }),
+                new Column({ header: new Text({ text: "Name" }) }),
+            ],
+            items: {
+                path: "/Products",
+                template: new ColumnListItem({
+                    cells: [
+                        new Text({ text: "{ProductID}" }),
+                        new Text({ text: "{ProductName}" }),
+                    ],
+                }),
+            },
+        })
+        oVHD.setTable(oTable)
+
+        // Create and set the FilterBar (advancedMode for in-dialog use)
+        var oFilterBar = new FilterBar({
+            advancedMode: true,
+            filterGroupItems: [/* FilterGroupItems */],
+        })
+        oVHD.setFilterBar(oFilterBar)
+
+        oVHD.open()
+    }
+)
+```
+
+## Conditions tab setup
+
+To define available fields in the Conditions tab:
+
+```javascript
+oVHD.setRangeKeyFields([
+    {
+        key: "ProductID",
+        label: "Product ID",
+        type: "string",
+    },
+    {
+        key: "Price",
+        label: "Price",
+        type: "numeric",
+    },
+])
+```
+
+## Key events
+
+| Event        | Purpose                                               |
+| ------------ | ----------------------------------------------------- |
+| `ok`         | Fired when user confirms selection (tokens available) |
+| `cancel`     | Fired when user cancels the dialog                    |
+| `afterClose` | Fired after dialog is closed                          |
+
+## Troubleshooting
+
+- Items tab empty: table not set via `setTable()` or binding path incorrect. Verify data binding on the table.
+- Conditions tab missing: `supportRanges` is `false`. Set `supportRanges="true"`.
+- Tokens not pre-selected: call `setTokens()` before `open()`. Tokens must match `key` property.
+- Filter not applied to table items: FilterBar `search` event must trigger table rebinding with filter parameters.
+- Dialog shows no columns: table has no `columns` aggregation defined. Add Column definitions to the table.
+- Cannot select multiple items: `supportMultiselect` is `false`. Set to `true` for multi-selection.


### PR DESCRIPTION
  - Add ui5-best-practices-smart-controls skill covering sap.ui.comp annotation-driven controls for OData V2
  (SmartField, SmartForm, SmartFilterBar, SmartChart, SmartLink, SmartMultiInput, FilterBar, ValueHelpDialog)
  - Add ui5-best-practices-mdc skill covering sap.ui.mdc delegate-based controls for OData V4 and JSON models
  (FilterBar, Chart, Field, FilterField, ValueHelp, Link, MultiValueField)
  - Update README.md with descriptions for both new skills

  Both skills follow the established pattern from ui5-best-practices-tables:
  - SKILL.md with trigger keywords, reference-loading table, core rules, selection matrix, common errors, and
  performance/accessibility guidance
  - Individual references/*.md files per control (~60-120 lines each) with API links, key properties/methods, XML/JS
  examples, and troubleshooting

JIRA: BGSOFUISAKAR-1630