### PR TITLE
fix(ui5): Enhance OPA5 configuration guidelines

### DIFF
--- a/plugins/ui5/skills/ui5-best-practices-opa5/references/configuration.md
+++ b/plugins/ui5/skills/ui5-best-practices-opa5/references/configuration.md
@@ -1,25 +1,27 @@
 # Configuration
 
-1. Use this folder layout:
+1. Use this folder layout for page objects and journeys:
 ```
 test/integration/
-├── opaTests.qunit.js   ← single entry point
 ├── pages/
 │   ├── Welcome.js      ← one page object per view (name matches the view)
 │   ├── Items.js
 │   └── Browser.js      ← cross-view actions (navigation, hash)
 ├── WelcomeJourney.js   ← one journey per feature/functionality
 └── FilterItemsJourney.js
+└── ...
 ```
 
-2. **ALWAYS** enable `autoWait` and define `viewNamespace` globally in `opaTests.qunit.js`.
+2. Default test entry point is `test/integration/opaTest.qunit.js`. Skip this file if your instructions already specify a different test entry point.
+
+3. **ALWAYS** enable `autoWait` and define `viewNamespace` globally in the test entry point.
 ```javascript
-// opaTests.qunit.js
+// in the test entry point 
 sap.ui.define(["sap/ui/test/Opa5"], (Opa5) => {
 	"use strict";
     Opa5.extendConfig({
 		autoWait: true,
-		viewNamespace: "com.myorg.myapp.view."
+		viewNamespace: "com.myorg.myapp.view." // Replace with your actual app namespace
 	});
 	// ...
 });


### PR DESCRIPTION
Problem:
The configuration guidelines in `ui5-best-practices-opa5` skill list test entry point `opaTests.qunit.js` but this file is not used in Fiori Elements test setup, as mentioned in issue #74

Solution:
Enhance the `ui5-best-practices-opa5` skill configuration guidelines to make them more generic

