### PR TITLE
fix(ui5): Remove duplicate mdc./smart.Table reference

### DIFF
--- a/plugins/ui5/skills/ui5-best-practices-mdc/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-mdc/SKILL.md
@@ -24,7 +24,6 @@ Apply these guidelines whenever generating, reviewing, or troubleshooting MDC co
 | Working on or planning a `sap.ui.mdc.Link`            | [`references/mdc-link.md`](references/mdc-link.md)                                                                       |
 | Working on or planning a `sap.ui.mdc.MultiValueField` | [`references/mdc-multi-value-field.md`](references/mdc-multi-value-field.md)                                             |
 | Using MDC controls with JSON model (non-OData)        | [`references/mdc-json-delegates.md`](references/mdc-json-delegates.md)                                                   |
-| Working on or planning a `sap.ui.mdc.Table`           | See `ui5-best-practices-tables` skill, [`references/mdc-table.md`](../ui5-best-practices-tables/references/mdc-table.md) |
 
 Load before producing any output. Do not work from memory.
 

--- a/plugins/ui5/skills/ui5-best-practices-smart-controls/SKILL.md
+++ b/plugins/ui5/skills/ui5-best-practices-smart-controls/SKILL.md
@@ -24,7 +24,6 @@ Apply these guidelines whenever generating, reviewing, or troubleshooting UI5 sm
 | Working on or planning a `sap.ui.comp.smartmultiinput.SmartMultiInput` | [`references/smart-multi-input.md`](references/smart-multi-input.md)                                                         |
 | Working on or planning a `sap.ui.comp.filterbar.FilterBar`             | [`references/filter-bar.md`](references/filter-bar.md)                                                                       |
 | Working on or planning a `sap.ui.comp.valuehelpdialog.ValueHelpDialog` | [`references/value-help-dialog.md`](references/value-help-dialog.md)                                                         |
-| Working on or planning a `sap.ui.comp.smarttable.SmartTable`           | See `ui5-best-practices-tables` skill, [`references/smart-table.md`](../ui5-best-practices-tables/references/smart-table.md) |
 
 Load before producing any output. Do not work from memory.
 


### PR DESCRIPTION
The `ui5-best-practices-mdc` and `ui5-best-practices-smart-controls` skills had a duplicate reference to the `mdc./smart.Table` skill.
This commit removes those references, as they are already covered in the `ui5-best-practices-tables` skill.
