### PR TITLE
feat: Support OpenAI Codex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         set -eu
         COPIES=(
           ".github/plugin/plugin.json"
+          ".codex-plugin/plugin.json"
         )
         failed=0
         for root in plugins/*/plugin.json; do

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 ## Further Information
 
 - [Claude Code Docs](https://code.claude.com/docs/)
+- [OpenAI Codex Plugins Docs](https://developers.openai.com/plugins/build/plugins)
 
 ## Support, Feedback, Contributing
 

--- a/docs/Guidelines.md
+++ b/docs/Guidelines.md
@@ -2,7 +2,7 @@
 
 ## Linting Guidelines
 
-Please ensure prettifing the `.mcp.json` and `.claude-plugin/plugin.json` using [Prettier](https://prettier.io/) by execute `npm run prettier` before you commit your change.  
+Please ensure prettifying the `.mcp.json` and `plugin.json` files using [Prettier](https://prettier.io/) by executing `npm run prettier` before you commit your change.
 
 ## Git Guidelines
 

--- a/plugins/ui5-modernization/.codex-plugin/plugin.json
+++ b/plugins/ui5-modernization/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+    "name": "ui5-modernization",
+    "version": "0.1.8",
+    "description": "Complete UI5 modernization toolkit with workflow and specialized fix patterns for modernizing SAPUI5/OpenUI5 applications",
+    "author": {
+        "name": "SAP SE"
+    },
+    "homepage": "https://github.com/UI5/plugins-coding-agents",
+    "repository": "https://github.com/UI5/plugins-coding-agents",
+    "keywords": [
+        "ui5",
+        "sapui5",
+        "openui5",
+        "modernization",
+        "linter",
+        "upgrade"
+    ],
+    "license": "Apache-2.0",
+    "skills": [
+        "./skills/"
+    ]
+}

--- a/plugins/ui5-modernization/README.md
+++ b/plugins/ui5-modernization/README.md
@@ -37,6 +37,18 @@ Use the `/plugin` command if you already started an interactive GitHub Copilot C
 /plugin install ui5-modernization@awesome-copilot
 ```
 
+### OpenAI Codex CLI
+
+```bash
+codex plugin install ui5-modernization@<registry-name>
+```
+
+Use the `/plugin` command if you already started an interactive OpenAI Codex CLI session.
+
+```bash
+/plugin install ui5-modernization@<registry-name>
+```
+
 ### Installing Skills Only
 
 If your coding agent doesn't support plugins, install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:

--- a/plugins/ui5-typescript-conversion/.codex-plugin/plugin.json
+++ b/plugins/ui5-typescript-conversion/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+    "name": "ui5-typescript-conversion",
+    "version": "0.1.8",
+    "description": "SAPUI5 / OpenUI5 plugin for coding agents. Converts JavaScript-based UI5 projects to TypeScript.",
+    "author": {
+        "name": "SAP SE"
+    },
+    "homepage": "https://github.com/UI5/plugins-coding-agents",
+    "repository": "https://github.com/UI5/plugins-coding-agents",
+    "license": "Apache-2.0",
+    "keywords": [
+        "sap",
+        "ui5",
+        "sapui5",
+        "openui5",
+        "plugin",
+        "typescript",
+        "conversion"
+    ],
+    "skills": [
+        "./skills/"
+    ]
+}

--- a/plugins/ui5-typescript-conversion/README.md
+++ b/plugins/ui5-typescript-conversion/README.md
@@ -30,6 +30,18 @@ Use the `/plugin` command if you already started an interactive GitHub Copilot C
 /plugin install ui5-typescript-conversion@awesome-copilot
 ```
 
+### OpenAI Codex CLI
+
+```bash
+codex plugin install ui5-typescript-conversion@<registry-name>
+```
+
+Use the `/plugin` command if you already started an interactive OpenAI Codex CLI session.
+
+```bash
+/plugin install ui5-typescript-conversion@<registry-name>
+```
+
 ### Installing Skills Only
 
 If your coding agent doesn't support plugins, install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:

--- a/plugins/ui5/.codex-plugin/plugin.json
+++ b/plugins/ui5/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+    "name": "ui5",
+    "version": "0.1.8",
+    "description": "SAPUI5 / OpenUI5 plugin for coding agents. Creates and validates UI5 projects, accesses API documentation, runs UI5 linter, retrieves development guidelines and best practices for UI5 development.",
+    "author": {
+        "name": "SAP SE"
+    },
+    "homepage": "https://github.com/UI5/plugins-coding-agents",
+    "repository": "https://github.com/UI5/plugins-coding-agents",
+    "license": "Apache-2.0",
+    "keywords": [
+        "sap",
+        "ui5",
+        "sapui5",
+        "openui5",
+        "opa5",
+        "qunit",
+        "plugin",
+        "linter",
+        "api-documentation",
+        "development-guidelines",
+        "best-practices"
+    ],
+    "skills": [
+        "./skills/"
+    ]
+}

--- a/plugins/ui5/README.md
+++ b/plugins/ui5/README.md
@@ -136,6 +136,18 @@ Use the `/plugin` command if you already started an interactive GitHub Copilot C
 /plugin install ui5@awesome-copilot
 ```
 
+### OpenAI Codex CLI
+
+```bash
+codex plugin install ui5@<registry-name>
+```
+
+Use the `/plugin` command if you already started an interactive OpenAI Codex CLI session.
+
+```bash
+/plugin install ui5@<registry-name>
+```
+
 ### Installing Skills Only
 
 If your coding agent doesn't support plugins, install the skills directly using the [skills](https://www.npmjs.com/package/skills) package:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -93,6 +93,21 @@
                     "type": "json",
                     "path": "plugins/ui5-modernization/.github/plugin/plugin.json",
                     "jsonpath": "$..version"
+                },
+                {
+                    "type": "json",
+                    "path": "plugins/ui5/.codex-plugin/plugin.json",
+                    "jsonpath": "$..version"
+                },
+                {
+                    "type": "json",
+                    "path": "plugins/ui5-typescript-conversion/.codex-plugin/plugin.json",
+                    "jsonpath": "$..version"
+                },
+                {
+                    "type": "json",
+                    "path": "plugins/ui5-modernization/.codex-plugin/plugin.json",
+                    "jsonpath": "$..version"
                 }
             ]
         }


### PR DESCRIPTION
 Add .codex-plugin/plugin.json manifests for all three plugins (ui5, ui5-modernization, ui5-typescript-conversion) to enable installation via the OpenAI Codex CLI.

- Add plugin.json manifests under .codex-plugin/ for each plugin
- Update READMEs with Codex CLI installation instructions
- Register .codex-plugin/plugin.json in release-please version bumps
- Add .codex-plugin/plugin.json to CI version-sync check
- Update docs/Guidelines.md to reference generic plugin.json files
- Add OpenAI Codex Plugins Docs link to root README

JIRA: CPOUI5FOUNDATION-1320

Closes: https://github.com/UI5/plugins-coding-agents/issues/101