### PR TITLE
fix(ui5): Enforce usage of latest UI5 MCP server

### DIFF
--- a/plugins/ui5/.mcp.json
+++ b/plugins/ui5/.mcp.json
@@ -2,7 +2,7 @@
     "mcpServers": {
         "ui5-mcp-server": {
             "command": "npx",
-            "args": ["-y", "@ui5/mcp-server"]
+            "args": ["-y", "@ui5/mcp-server@latest"]
         }
     }
 }


### PR DESCRIPTION
Users might get an outdated version of `@ui5/mcp-server`. Therefore, enforce the agent to install the latest version.

https://github.com/npm/cli/issues/4108